### PR TITLE
DynamiTe's NLA termination benchmarks

### DIFF
--- a/c/termination-nla/LICENSE.txt
+++ b/c/termination-nla/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/c/termination-nla/Makefile
+++ b/c/termination-nla/Makefile
@@ -1,0 +1,10 @@
+# This file is part of the SV-Benchmarks collection of verification tasks:
+# https://github.com/sosy-lab/sv-benchmarks
+#
+# SPDX-FileCopyrightText: 2015-2016 Daniel Liew <dan@su-root.co.uk>
+# SPDX-FileCopyrightText: 2015-2020 The SV-Benchmarks Community
+#
+# SPDX-License-Identifier: Apache-2.0
+
+LEVEL := ../
+include $(LEVEL)/Makefile.config

--- a/c/termination-nla/README.md
+++ b/c/termination-nla/README.md
@@ -1,0 +1,8 @@
+The benchmarks in this directory were submitted by 
+Ton Chanh Le (letonchanh@gmail.com).
+
+These programs contain nonlinear polynomial properties 
+(mostly equalities) that are challenging for proving their termination and non-termination.
+
+These programs were adapted from the SV-COMP `nla-digbench` benchmark and have been used in the DynamiTe work:
+* Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen. DynamiTe: Dynamic termination and non-termination proofs. Proceedings of the ACM on Programming Languages, Volume 4, Issue OOPSLA. November 2020. Article No.: 189, pp 1–30. https://doi.org/10.1145/3428257.

--- a/c/termination-nla/bresenham1-both-nt.c
+++ b/c/termination-nla/bresenham1-both-nt.c
@@ -1,0 +1,53 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+  Bresenham's line drawing algorithm 
+  from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
+*/
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int X, Y;
+    int v, x, y;
+    X = __VERIFIER_nondet_int();
+    Y = __VERIFIER_nondet_int();
+    v = 2 * Y - X;
+    y = 0;
+    x = 0;
+    int c, k;
+    c = 0;
+
+    while (2*Y*x - 2*X*y - X + 2*Y - v == 0) {
+      //__VERIFIER_assert(2*Y*x - 2*X*y - X + 2*Y - v == 0);
+      //if (!(x <= X))            break;
+        // out[x] = y
+
+        if (v < 0) {
+            v = v + 2 * Y;
+        } else {
+            v = v + 2 * (Y - X);
+            y++;
+        }
+        x++;
+        c++;
+    }
+    //__VERIFIER_assert(2*Y*x - 2*x*y - X + 2*Y - v + 2*y == 0);
+
+    return 0;
+}

--- a/c/termination-nla/bresenham1-both-nt.i
+++ b/c/termination-nla/bresenham1-both-nt.i
@@ -1,0 +1,23 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int X, Y;
+    int v, x, y;
+    X = __VERIFIER_nondet_int();
+    Y = __VERIFIER_nondet_int();
+    v = 2 * Y - X;
+    y = 0;
+    x = 0;
+    int c, k;
+    c = 0;
+    while (2*Y*x - 2*X*y - X + 2*Y - v == 0) {
+        if (v < 0) {
+            v = v + 2 * Y;
+        } else {
+            v = v + 2 * (Y - X);
+            y++;
+        }
+        x++;
+        c++;
+    }
+    return 0;
+}

--- a/c/termination-nla/bresenham1-both-nt.yml
+++ b/c/termination-nla/bresenham1-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'bresenham1-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/bresenham1-both-t.c
+++ b/c/termination-nla/bresenham1-both-t.c
@@ -1,0 +1,54 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+  Bresenham's line drawing algorithm 
+  from Srivastava et al.'s paper From Program Verification to Program Synthesis in POPL '10 
+*/
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int X, Y;
+    int v, x, y;
+    X = __VERIFIER_nondet_int();
+    Y = __VERIFIER_nondet_int();
+    v = 2 * Y - X;
+    y = 0;
+    x = 0;
+    int c, k;
+    c = 0;
+    k = __VERIFIER_nondet_int();
+
+    while (2*Y*x - 2*X*y - X + 2*Y - v + c <= k) {
+      //__VERIFIER_assert(2*Y*x - 2*X*y - X + 2*Y - v == 0);
+      //if (!(x <= X))            break;
+        // out[x] = y
+
+        if (v < 0) {
+            v = v + 2 * Y;
+        } else {
+            v = v + 2 * (Y - X);
+            y++;
+        }
+        x++;
+        c++;
+    }
+    //__VERIFIER_assert(2*Y*x - 2*x*y - X + 2*Y - v + 2*y == 0);
+
+    return 0;
+}

--- a/c/termination-nla/bresenham1-both-t.i
+++ b/c/termination-nla/bresenham1-both-t.i
@@ -1,0 +1,24 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int X, Y;
+    int v, x, y;
+    X = __VERIFIER_nondet_int();
+    Y = __VERIFIER_nondet_int();
+    v = 2 * Y - X;
+    y = 0;
+    x = 0;
+    int c, k;
+    c = 0;
+    k = __VERIFIER_nondet_int();
+    while (2*Y*x - 2*X*y - X + 2*Y - v + c <= k) {
+        if (v < 0) {
+            v = v + 2 * Y;
+        } else {
+            v = v + 2 * (Y - X);
+            y++;
+        }
+        x++;
+        c++;
+    }
+    return 0;
+}

--- a/c/termination-nla/bresenham1-both-t.yml
+++ b/c/termination-nla/bresenham1-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'bresenham1-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/cohencu1-both-nt.c
+++ b/c/termination-nla/cohencu1-both-nt.c
@@ -1,0 +1,57 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+Printing consecutive cubes, by Cohen
+http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
+*/
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+
+    while (z <= 6 * n + 6) {
+      //__VERIFIER_assert(z == 6 * n + 6);
+      //__VERIFIER_assert(y == 3 * n * n + 3 * n + 1);
+      //__VERIFIER_assert(x == n * n * n);
+      //__VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+      //__VERIFIER_assert((z*z) - 12*y - 6*z + 12 == 0);
+        //if (!(n <= a))            break;
+
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    /*
+    __VERIFIER_assert(z == 6*n + 6);
+    __VERIFIER_assert(6*a*x - x*z + 12*x == 0);
+    __VERIFIER_assert(a*z - 6*a - 2*y + 2*z - 10 == 0);
+    __VERIFIER_assert(2*y*y - 3*x*z - 18*x - 10*y + 3*z - 10 == 0);
+    __VERIFIER_assert(z*z - 12*y - 6*z + 12 == 0);
+    __VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+    */    
+    return 0;
+}

--- a/c/termination-nla/cohencu1-both-nt.i
+++ b/c/termination-nla/cohencu1-both-nt.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    while (z <= 6 * n + 6) {
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    return 0;
+}

--- a/c/termination-nla/cohencu1-both-nt.yml
+++ b/c/termination-nla/cohencu1-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'cohencu1-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/cohencu1-both-t.c
+++ b/c/termination-nla/cohencu1-both-t.c
@@ -1,0 +1,58 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+Printing consecutive cubes, by Cohen
+http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
+*/
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    int k = __VERIFIER_nondet_int();
+
+    while (6 * n + 6 <= k) {
+      //__VERIFIER_assert(z == 6 * n + 6);
+      //__VERIFIER_assert(y == 3 * n * n + 3 * n + 1);
+      //__VERIFIER_assert(x == n * n * n);
+      //__VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+      //__VERIFIER_assert((z*z) - 12*y - 6*z + 12 == 0);
+        //if (!(n <= a))            break;
+
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    /*
+    __VERIFIER_assert(z == 6*n + 6);
+    __VERIFIER_assert(6*a*x - x*z + 12*x == 0);
+    __VERIFIER_assert(a*z - 6*a - 2*y + 2*z - 10 == 0);
+    __VERIFIER_assert(2*y*y - 3*x*z - 18*x - 10*y + 3*z - 10 == 0);
+    __VERIFIER_assert(z*z - 12*y - 6*z + 12 == 0);
+    __VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+    */    
+    return 0;
+}

--- a/c/termination-nla/cohencu1-both-t.i
+++ b/c/termination-nla/cohencu1-both-t.i
@@ -1,0 +1,17 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    int k = __VERIFIER_nondet_int();
+    while (6 * n + 6 <= k) {
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    return 0;
+}

--- a/c/termination-nla/cohencu1-both-t.yml
+++ b/c/termination-nla/cohencu1-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'cohencu1-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/cohencu2-both-nt.c
+++ b/c/termination-nla/cohencu2-both-nt.c
@@ -1,0 +1,56 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+Printing consecutive cubes, by Cohen
+http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
+*/
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    
+    while (y == 3 * n * n + 3 * n + 1) {
+      //__VERIFIER_assert(z == 6 * n + 6);
+      //__VERIFIER_assert(y == 3 * n * n + 3 * n + 1);
+      //__VERIFIER_assert(x == n * n * n);
+      //__VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+      //__VERIFIER_assert((z*z) - 12*y - 6*z + 12 == 0);
+        //if (!(n <= a))            break;
+
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    /*
+    __VERIFIER_assert(z == 6*n + 6);
+    __VERIFIER_assert(6*a*x - x*z + 12*x == 0);
+    __VERIFIER_assert(a*z - 6*a - 2*y + 2*z - 10 == 0);
+    __VERIFIER_assert(2*y*y - 3*x*z - 18*x - 10*y + 3*z - 10 == 0);
+    __VERIFIER_assert(z*z - 12*y - 6*z + 12 == 0);
+    __VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+    */    
+    return 0;
+}

--- a/c/termination-nla/cohencu2-both-nt.i
+++ b/c/termination-nla/cohencu2-both-nt.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    while (y == 3 * n * n + 3 * n + 1) {
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    return 0;
+}

--- a/c/termination-nla/cohencu2-both-nt.yml
+++ b/c/termination-nla/cohencu2-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'cohencu2-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/cohencu2-both-t.c
+++ b/c/termination-nla/cohencu2-both-t.c
@@ -1,0 +1,56 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+Printing consecutive cubes, by Cohen
+http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
+*/
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    int k = __VERIFIER_nondet_int();
+    while (3 * n * n + 3 * n + 1 <= k) {
+      //__VERIFIER_assert(z == 6 * n + 6);
+      //__VERIFIER_assert(y == 3 * n * n + 3 * n + 1);
+      //__VERIFIER_assert(x == n * n * n);
+      //__VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+      //__VERIFIER_assert((z*z) - 12*y - 6*z + 12 == 0);
+        //if (!(n <= a))            break;
+
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    /*
+    __VERIFIER_assert(z == 6*n + 6);
+    __VERIFIER_assert(6*a*x - x*z + 12*x == 0);
+    __VERIFIER_assert(a*z - 6*a - 2*y + 2*z - 10 == 0);
+    __VERIFIER_assert(2*y*y - 3*x*z - 18*x - 10*y + 3*z - 10 == 0);
+    __VERIFIER_assert(z*z - 12*y - 6*z + 12 == 0);
+    __VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+    */    
+    return 0;
+}

--- a/c/termination-nla/cohencu2-both-t.i
+++ b/c/termination-nla/cohencu2-both-t.i
@@ -1,0 +1,17 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    int k = __VERIFIER_nondet_int();
+    while (3 * n * n + 3 * n + 1 <= k) {
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    return 0;
+}

--- a/c/termination-nla/cohencu2-both-t.yml
+++ b/c/termination-nla/cohencu2-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'cohencu2-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/cohencu3-both-nt.c
+++ b/c/termination-nla/cohencu3-both-nt.c
@@ -1,0 +1,56 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+Printing consecutive cubes, by Cohen
+http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
+*/
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    
+    while (x == n * n * n) {
+      //__VERIFIER_assert(z == 6 * n + 6);
+      //__VERIFIER_assert(y == 3 * n * n + 3 * n + 1);
+      //__VERIFIER_assert(x == n * n * n);
+      //__VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+      //__VERIFIER_assert((z*z) - 12*y - 6*z + 12 == 0);
+        //if (!(n <= a))            break;
+
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    /*
+    __VERIFIER_assert(z == 6*n + 6);
+    __VERIFIER_assert(6*a*x - x*z + 12*x == 0);
+    __VERIFIER_assert(a*z - 6*a - 2*y + 2*z - 10 == 0);
+    __VERIFIER_assert(2*y*y - 3*x*z - 18*x - 10*y + 3*z - 10 == 0);
+    __VERIFIER_assert(z*z - 12*y - 6*z + 12 == 0);
+    __VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+    */    
+    return 0;
+}

--- a/c/termination-nla/cohencu3-both-nt.i
+++ b/c/termination-nla/cohencu3-both-nt.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    while (x == n * n * n) {
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    return 0;
+}

--- a/c/termination-nla/cohencu3-both-nt.yml
+++ b/c/termination-nla/cohencu3-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'cohencu3-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/cohencu3-both-t.c
+++ b/c/termination-nla/cohencu3-both-t.c
@@ -1,0 +1,56 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+Printing consecutive cubes, by Cohen
+http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
+*/
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    int k = __VERIFIER_nondet_int();
+    while (n * n * n <= k) {
+      //__VERIFIER_assert(z == 6 * n + 6);
+      //__VERIFIER_assert(y == 3 * n * n + 3 * n + 1);
+      //__VERIFIER_assert(x == n * n * n);
+      //__VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+      //__VERIFIER_assert((z*z) - 12*y - 6*z + 12 == 0);
+        //if (!(n <= a))            break;
+
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    /*
+    __VERIFIER_assert(z == 6*n + 6);
+    __VERIFIER_assert(6*a*x - x*z + 12*x == 0);
+    __VERIFIER_assert(a*z - 6*a - 2*y + 2*z - 10 == 0);
+    __VERIFIER_assert(2*y*y - 3*x*z - 18*x - 10*y + 3*z - 10 == 0);
+    __VERIFIER_assert(z*z - 12*y - 6*z + 12 == 0);
+    __VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+    */    
+    return 0;
+}

--- a/c/termination-nla/cohencu3-both-t.i
+++ b/c/termination-nla/cohencu3-both-t.i
@@ -1,0 +1,17 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    int k = __VERIFIER_nondet_int();
+    while (n * n * n <= k) {
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    return 0;
+}

--- a/c/termination-nla/cohencu3-both-t.yml
+++ b/c/termination-nla/cohencu3-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'cohencu3-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/cohencu4-both-nt.c
+++ b/c/termination-nla/cohencu4-both-nt.c
@@ -1,0 +1,56 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+Printing consecutive cubes, by Cohen
+http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
+*/
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+
+    while (y*z - 18*x - 12*y + 2*z - 6 == 0) {
+      //__VERIFIER_assert(z == 6 * n + 6);
+      //__VERIFIER_assert(y == 3 * n * n + 3 * n + 1);
+      //__VERIFIER_assert(x == n * n * n);
+      //__VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+      //__VERIFIER_assert((z*z) - 12*y - 6*z + 12 == 0);
+        //if (!(n <= a))            break;
+
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    /*
+    __VERIFIER_assert(z == 6*n + 6);
+    __VERIFIER_assert(6*a*x - x*z + 12*x == 0);
+    __VERIFIER_assert(a*z - 6*a - 2*y + 2*z - 10 == 0);
+    __VERIFIER_assert(2*y*y - 3*x*z - 18*x - 10*y + 3*z - 10 == 0);
+    __VERIFIER_assert(z*z - 12*y - 6*z + 12 == 0);
+    __VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+    */    
+    return 0;
+}

--- a/c/termination-nla/cohencu4-both-nt.i
+++ b/c/termination-nla/cohencu4-both-nt.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    while (y*z - 18*x - 12*y + 2*z - 6 == 0) {
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    return 0;
+}

--- a/c/termination-nla/cohencu4-both-nt.yml
+++ b/c/termination-nla/cohencu4-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'cohencu4-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/cohencu4-both-t.c
+++ b/c/termination-nla/cohencu4-both-t.c
@@ -1,0 +1,57 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+Printing consecutive cubes, by Cohen
+http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
+*/
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    int c = 0, k = __VERIFIER_nondet_int();
+    while (y*z - 18*x - 12*y + 2*z - 6 + c <= k) {
+      //__VERIFIER_assert(z == 6 * n + 6);
+      //__VERIFIER_assert(y == 3 * n * n + 3 * n + 1);
+      //__VERIFIER_assert(x == n * n * n);
+      //__VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+      //__VERIFIER_assert((z*z) - 12*y - 6*z + 12 == 0);
+        //if (!(n <= a))            break;
+
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+        c = c + 1;
+    }
+    /*
+    __VERIFIER_assert(z == 6*n + 6);
+    __VERIFIER_assert(6*a*x - x*z + 12*x == 0);
+    __VERIFIER_assert(a*z - 6*a - 2*y + 2*z - 10 == 0);
+    __VERIFIER_assert(2*y*y - 3*x*z - 18*x - 10*y + 3*z - 10 == 0);
+    __VERIFIER_assert(z*z - 12*y - 6*z + 12 == 0);
+    __VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+    */    
+    return 0;
+}

--- a/c/termination-nla/cohencu4-both-t.i
+++ b/c/termination-nla/cohencu4-both-t.i
@@ -1,0 +1,18 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    int c = 0, k = __VERIFIER_nondet_int();
+    while (y*z - 18*x - 12*y + 2*z - 6 + c <= k) {
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+        c = c + 1;
+    }
+    return 0;
+}

--- a/c/termination-nla/cohencu4-both-t.yml
+++ b/c/termination-nla/cohencu4-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'cohencu4-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/cohencu5-both-nt.c
+++ b/c/termination-nla/cohencu5-both-nt.c
@@ -1,0 +1,56 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+Printing consecutive cubes, by Cohen
+http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
+*/
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    
+    while ((z*z) - 12*y - 6*z + 12 == 0) {
+      //__VERIFIER_assert(z == 6 * n + 6);
+      //__VERIFIER_assert(y == 3 * n * n + 3 * n + 1);
+      //__VERIFIER_assert(x == n * n * n);
+      //__VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+      //__VERIFIER_assert((z*z) - 12*y - 6*z + 12 == 0);
+        //if (!(n <= a))            break;
+
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    /*
+    __VERIFIER_assert(z == 6*n + 6);
+    __VERIFIER_assert(6*a*x - x*z + 12*x == 0);
+    __VERIFIER_assert(a*z - 6*a - 2*y + 2*z - 10 == 0);
+    __VERIFIER_assert(2*y*y - 3*x*z - 18*x - 10*y + 3*z - 10 == 0);
+    __VERIFIER_assert(z*z - 12*y - 6*z + 12 == 0);
+    __VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+    */    
+    return 0;
+}

--- a/c/termination-nla/cohencu5-both-nt.i
+++ b/c/termination-nla/cohencu5-both-nt.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    while ((z*z) - 12*y - 6*z + 12 == 0) {
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    return 0;
+}

--- a/c/termination-nla/cohencu5-both-nt.yml
+++ b/c/termination-nla/cohencu5-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'cohencu5-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/cohencu5-both-t.c
+++ b/c/termination-nla/cohencu5-both-t.c
@@ -1,0 +1,58 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+Printing consecutive cubes, by Cohen
+http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
+*/
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    int c = 0, k = __VERIFIER_nondet_int();
+    
+    while ((z*z) - 12*y - 6*z + 12 + c <= k) {
+      //__VERIFIER_assert(z == 6 * n + 6);
+      //__VERIFIER_assert(y == 3 * n * n + 3 * n + 1);
+      //__VERIFIER_assert(x == n * n * n);
+      //__VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+      //__VERIFIER_assert((z*z) - 12*y - 6*z + 12 == 0);
+        //if (!(n <= a))            break;
+
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+        c = c + 1;
+    }
+    /*
+    __VERIFIER_assert(z == 6*n + 6);
+    __VERIFIER_assert(6*a*x - x*z + 12*x == 0);
+    __VERIFIER_assert(a*z - 6*a - 2*y + 2*z - 10 == 0);
+    __VERIFIER_assert(2*y*y - 3*x*z - 18*x - 10*y + 3*z - 10 == 0);
+    __VERIFIER_assert(z*z - 12*y - 6*z + 12 == 0);
+    __VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+    */    
+    return 0;
+}

--- a/c/termination-nla/cohencu5-both-t.i
+++ b/c/termination-nla/cohencu5-both-t.i
@@ -1,0 +1,18 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    int c = 0, k = __VERIFIER_nondet_int();
+    while ((z*z) - 12*y - 6*z + 12 + c <= k) {
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+        c = c + 1;
+    }
+    return 0;
+}

--- a/c/termination-nla/cohencu5-both-t.yml
+++ b/c/termination-nla/cohencu5-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'cohencu5-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/cohencu6-both-t.c
+++ b/c/termination-nla/cohencu6-both-t.c
@@ -1,0 +1,57 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+Printing consecutive cubes, by Cohen
+http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
+*/
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+
+    while (n <= a) {
+      //__VERIFIER_assert(z == 6 * n + 6);
+      //__VERIFIER_assert(y == 3 * n * n + 3 * n + 1);
+      //__VERIFIER_assert(x == n * n * n);
+      //__VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+      //__VERIFIER_assert((z*z) - 12*y - 6*z + 12 == 0);
+        //if (!(n <= a))            break;
+
+        //n = n + 1;
+        n = n + y - 3*n*n - 3*n; 
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    /*
+    __VERIFIER_assert(z == 6*n + 6);
+    __VERIFIER_assert(6*a*x - x*z + 12*x == 0);
+    __VERIFIER_assert(a*z - 6*a - 2*y + 2*z - 10 == 0);
+    __VERIFIER_assert(2*y*y - 3*x*z - 18*x - 10*y + 3*z - 10 == 0);
+    __VERIFIER_assert(z*z - 12*y - 6*z + 12 == 0);
+    __VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+    */    
+    return 0;
+}

--- a/c/termination-nla/cohencu6-both-t.i
+++ b/c/termination-nla/cohencu6-both-t.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    while (n <= a) {
+        n = n + y - 3*n*n - 3*n;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    return 0;
+}

--- a/c/termination-nla/cohencu6-both-t.yml
+++ b/c/termination-nla/cohencu6-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'cohencu6-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/cohencu7-both-t.c
+++ b/c/termination-nla/cohencu7-both-t.c
@@ -1,0 +1,58 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+Printing consecutive cubes, by Cohen
+http://www.cs.upc.edu/~erodri/webpage/polynomial_invariants/cohencu.htm
+*/
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+
+    if (-1000 <= a && a <= 1000) {
+    while (x + y <= (a + 1)*(a + 1)*(a + 1)) {
+      //__VERIFIER_assert(z == 6 * n + 6);
+      //__VERIFIER_assert(y == 3 * n * n + 3 * n + 1);
+      //__VERIFIER_assert(x == n * n * n);
+      //__VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+      //__VERIFIER_assert((z*z) - 12*y - 6*z + 12 == 0);
+        //if (!(n <= a))            break;
+
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    }
+    /*
+    __VERIFIER_assert(z == 6*n + 6);
+    __VERIFIER_assert(6*a*x - x*z + 12*x == 0);
+    __VERIFIER_assert(a*z - 6*a - 2*y + 2*z - 10 == 0);
+    __VERIFIER_assert(2*y*y - 3*x*z - 18*x - 10*y + 3*z - 10 == 0);
+    __VERIFIER_assert(z*z - 12*y - 6*z + 12 == 0);
+    __VERIFIER_assert(y*z - 18*x - 12*y + 2*z - 6 == 0);
+    */    
+    return 0;
+}

--- a/c/termination-nla/cohencu7-both-t.i
+++ b/c/termination-nla/cohencu7-both-t.i
@@ -1,0 +1,18 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, n, x, y, z;
+    a = __VERIFIER_nondet_int();
+    n = 0;
+    x = 0;
+    y = 1;
+    z = 6;
+    if (-1000 <= a && a <= 1000) {
+    while (x + y <= (a + 1)*(a + 1)*(a + 1)) {
+        n = n + 1;
+        x = x + y;
+        y = y + z;
+        z = z + 6;
+    }
+    }
+    return 0;
+}

--- a/c/termination-nla/cohencu7-both-t.yml
+++ b/c/termination-nla/cohencu7-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'cohencu7-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/dijkstra1-both-nt.c
+++ b/c/termination-nla/dijkstra1-both-nt.c
@@ -1,0 +1,68 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Compute the floor of the square root, by Dijkstra */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int n, p, q, r, h;
+
+    n = __VERIFIER_nondet_int();
+
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+
+    /*
+    while ( q <= n ) {
+      // if (!(q <= n)) break;
+
+        q = 4 * q;
+    }
+    //q == 4^n
+    */
+
+    if (q > n) {
+    while (r < 2 * p + q) {
+      //__VERIFIER_assert(r < 2 * p + q);
+      //__VERIFIER_assert(p*p + r*q == n*q);
+      //__VERIFIER_assert(h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r == 0);
+      //__VERIFIER_assert(h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r == 0);
+      //__VERIFIER_assert(h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r == 0);
+      //__VERIFIER_assert(p * p - n * q + q * r == 0);
+
+      //if (!(q != 1))
+      //    break;
+      if (4 * (q / 4) == q && 2 * (p / 2) == p) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+      }
+      }
+    }
+    //__VERIFIER_assert(h*h*h - 12*h*n + 16*n*p + 12*h*r - 16*p*r - h - 4*p == 0);
+    //__VERIFIER_assert(p*p - n + r == 0);
+    //__VERIFIER_assert(h*h*p - 4*h*n + 4*n*p + 4*h*r - 4*p*r - p == 0);
+    return 0;
+}

--- a/c/termination-nla/dijkstra1-both-nt.i
+++ b/c/termination-nla/dijkstra1-both-nt.i
@@ -1,0 +1,23 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int n, p, q, r, h;
+    n = __VERIFIER_nondet_int();
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    if (q > n) {
+    while (r < 2 * p + q) {
+      if (4 * (q / 4) == q && 2 * (p / 2) == p) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+      }
+      }
+    }
+    return 0;
+}

--- a/c/termination-nla/dijkstra1-both-nt.yml
+++ b/c/termination-nla/dijkstra1-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'dijkstra1-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/dijkstra1-both-t.c
+++ b/c/termination-nla/dijkstra1-both-t.c
@@ -1,0 +1,62 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Compute the floor of the square root, by Dijkstra */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int n, p, q, r, h;
+
+    n = __VERIFIER_nondet_int();
+
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    while ( q <= n ) {
+      // if (!(q <= n)) break;
+
+        q = 4 * q;
+    }
+    //q == 4^n
+
+    while (r >= 2 * p + q) {
+      //__VERIFIER_assert(r < 2 * p + q);
+      //__VERIFIER_assert(p*p + r*q == n*q);
+      //__VERIFIER_assert(h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r == 0);
+      //__VERIFIER_assert(h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r == 0);
+      //__VERIFIER_assert(h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r == 0);
+      //__VERIFIER_assert(p * p - n * q + q * r == 0);
+
+      //if (!(q != 1))
+      //    break;
+
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+    }
+    //__VERIFIER_assert(h*h*h - 12*h*n + 16*n*p + 12*h*r - 16*p*r - h - 4*p == 0);
+    //__VERIFIER_assert(p*p - n + r == 0);
+    //__VERIFIER_assert(h*h*p - 4*h*n + 4*n*p + 4*h*r - 4*p*r - p == 0);
+    return 0;
+}

--- a/c/termination-nla/dijkstra1-both-t.i
+++ b/c/termination-nla/dijkstra1-both-t.i
@@ -1,0 +1,22 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int n, p, q, r, h;
+    n = __VERIFIER_nondet_int();
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    while ( q <= n ) {
+        q = 4 * q;
+    }
+    while (r >= 2 * p + q) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/dijkstra1-both-t.yml
+++ b/c/termination-nla/dijkstra1-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'dijkstra1-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/dijkstra2-both-nt.c
+++ b/c/termination-nla/dijkstra2-both-nt.c
@@ -1,0 +1,68 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Compute the floor of the square root, by Dijkstra */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int n, p, q, r, h;
+
+    n = __VERIFIER_nondet_int();
+
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+
+    /*
+    while ( q <= n ) {
+      // if (!(q <= n)) break;
+
+        q = 4 * q;
+    }
+    //q == 4^n
+    */
+
+    if (q > n) {
+    while (p*p + r*q == n*q) {
+      //__VERIFIER_assert(r < 2 * p + q);
+      //__VERIFIER_assert(p*p + r*q == n*q);
+      //__VERIFIER_assert(h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r == 0);
+      //__VERIFIER_assert(h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r == 0);
+      //__VERIFIER_assert(h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r == 0);
+      //__VERIFIER_assert(p * p - n * q + q * r == 0);
+
+      //if (!(q != 1))
+      //    break;
+      if (4 * (q / 4) == q && 2 * (p / 2) == p) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+      }
+      }
+    }
+    //__VERIFIER_assert(h*h*h - 12*h*n + 16*n*p + 12*h*r - 16*p*r - h - 4*p == 0);
+    //__VERIFIER_assert(p*p - n + r == 0);
+    //__VERIFIER_assert(h*h*p - 4*h*n + 4*n*p + 4*h*r - 4*p*r - p == 0);
+    return 0;
+}

--- a/c/termination-nla/dijkstra2-both-nt.i
+++ b/c/termination-nla/dijkstra2-both-nt.i
@@ -1,0 +1,23 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int n, p, q, r, h;
+    n = __VERIFIER_nondet_int();
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    if (q > n) {
+    while (p*p + r*q == n*q) {
+      if (4 * (q / 4) == q && 2 * (p / 2) == p) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+      }
+      }
+    }
+    return 0;
+}

--- a/c/termination-nla/dijkstra2-both-nt.yml
+++ b/c/termination-nla/dijkstra2-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'dijkstra2-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/dijkstra2-both-t.c
+++ b/c/termination-nla/dijkstra2-both-t.c
@@ -1,0 +1,64 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Compute the floor of the square root, by Dijkstra */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int n, p, q, r, h;
+
+    n = __VERIFIER_nondet_int();
+
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    int c = 0, k = __VERIFIER_nondet_int();
+    while ( q <= n ) {
+      // if (!(q <= n)) break;
+
+        q = 4 * q;
+    }
+    //q == 4^n
+
+    while (p*p + r*q - n*q + c <= k) {
+      //__VERIFIER_assert(r < 2 * p + q);
+      //__VERIFIER_assert(p*p + r*q == n*q);
+      //__VERIFIER_assert(h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r == 0);
+      //__VERIFIER_assert(h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r == 0);
+      //__VERIFIER_assert(h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r == 0);
+      //__VERIFIER_assert(p * p - n * q + q * r == 0);
+
+      //if (!(q != 1))
+      //    break;
+
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+        c++;
+    }
+    //__VERIFIER_assert(h*h*h - 12*h*n + 16*n*p + 12*h*r - 16*p*r - h - 4*p == 0);
+    //__VERIFIER_assert(p*p - n + r == 0);
+    //__VERIFIER_assert(h*h*p - 4*h*n + 4*n*p + 4*h*r - 4*p*r - p == 0);
+    return 0;
+}

--- a/c/termination-nla/dijkstra2-both-t.i
+++ b/c/termination-nla/dijkstra2-both-t.i
@@ -1,0 +1,24 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int n, p, q, r, h;
+    n = __VERIFIER_nondet_int();
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    int c = 0, k = __VERIFIER_nondet_int();
+    while ( q <= n ) {
+        q = 4 * q;
+    }
+    while (p*p + r*q - n*q + c <= k) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+        c++;
+    }
+    return 0;
+}

--- a/c/termination-nla/dijkstra2-both-t.yml
+++ b/c/termination-nla/dijkstra2-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'dijkstra2-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/dijkstra3-both-nt.c
+++ b/c/termination-nla/dijkstra3-both-nt.c
@@ -1,0 +1,68 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Compute the floor of the square root, by Dijkstra */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int n, p, q, r, h;
+
+    n = __VERIFIER_nondet_int();
+
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+
+    /*
+    while ( q <= n ) {
+      // if (!(q <= n)) break;
+
+        q = 4 * q;
+    }
+    //q == 4^n
+    */
+
+    if (q > n) {
+    while (h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r == 0) {
+      //__VERIFIER_assert(r < 2 * p + q);
+      //__VERIFIER_assert(p*p + r*q == n*q);
+      //__VERIFIER_assert(h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r == 0);
+      //__VERIFIER_assert(h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r == 0);
+      //__VERIFIER_assert(h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r == 0);
+      //__VERIFIER_assert(p * p - n * q + q * r == 0);
+
+      //if (!(q != 1))
+      //    break;
+      if (4 * (q / 4) == q && 2 * (p / 2) == p) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+      }
+      }
+    }
+    //__VERIFIER_assert(h*h*h - 12*h*n + 16*n*p + 12*h*r - 16*p*r - h - 4*p == 0);
+    //__VERIFIER_assert(p*p - n + r == 0);
+    //__VERIFIER_assert(h*h*p - 4*h*n + 4*n*p + 4*h*r - 4*p*r - p == 0);
+    return 0;
+}

--- a/c/termination-nla/dijkstra3-both-nt.i
+++ b/c/termination-nla/dijkstra3-both-nt.i
@@ -1,0 +1,23 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int n, p, q, r, h;
+    n = __VERIFIER_nondet_int();
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    if (q > n) {
+    while (h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r == 0) {
+      if (4 * (q / 4) == q && 2 * (p / 2) == p) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+      }
+      }
+    }
+    return 0;
+}

--- a/c/termination-nla/dijkstra3-both-nt.yml
+++ b/c/termination-nla/dijkstra3-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'dijkstra3-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/dijkstra3-both-t.c
+++ b/c/termination-nla/dijkstra3-both-t.c
@@ -1,0 +1,64 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Compute the floor of the square root, by Dijkstra */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int n, p, q, r, h;
+
+    n = __VERIFIER_nondet_int();
+
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    int c = 0, k = __VERIFIER_nondet_int();
+    while ( q <= n ) {
+      // if (!(q <= n)) break;
+
+        q = 4 * q;
+    }
+    //q == 4^n
+
+    while (h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r + c <= k) {
+      //__VERIFIER_assert(r < 2 * p + q);
+      //__VERIFIER_assert(p*p + r*q == n*q);
+      //__VERIFIER_assert(h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r == 0);
+      //__VERIFIER_assert(h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r == 0);
+      //__VERIFIER_assert(h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r == 0);
+      //__VERIFIER_assert(p * p - n * q + q * r == 0);
+
+      //if (!(q != 1))
+      //    break;
+
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+        c++;
+    }
+    //__VERIFIER_assert(h*h*h - 12*h*n + 16*n*p + 12*h*r - 16*p*r - h - 4*p == 0);
+    //__VERIFIER_assert(p*p - n + r == 0);
+    //__VERIFIER_assert(h*h*p - 4*h*n + 4*n*p + 4*h*r - 4*p*r - p == 0);
+    return 0;
+}

--- a/c/termination-nla/dijkstra3-both-t.i
+++ b/c/termination-nla/dijkstra3-both-t.i
@@ -1,0 +1,24 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int n, p, q, r, h;
+    n = __VERIFIER_nondet_int();
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    int c = 0, k = __VERIFIER_nondet_int();
+    while ( q <= n ) {
+        q = 4 * q;
+    }
+    while (h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r + c <= k) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+        c++;
+    }
+    return 0;
+}

--- a/c/termination-nla/dijkstra3-both-t.yml
+++ b/c/termination-nla/dijkstra3-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'dijkstra3-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/dijkstra4-both-nt.c
+++ b/c/termination-nla/dijkstra4-both-nt.c
@@ -1,0 +1,68 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Compute the floor of the square root, by Dijkstra */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int n, p, q, r, h;
+
+    n = __VERIFIER_nondet_int();
+
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+
+    /*
+    while ( q <= n ) {
+      // if (!(q <= n)) break;
+
+        q = 4 * q;
+    }
+    //q == 4^n
+    */
+
+    if (q > n) {
+    while (h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r == 0) {
+      //__VERIFIER_assert(r < 2 * p + q);
+      //__VERIFIER_assert(p*p + r*q == n*q);
+      //__VERIFIER_assert(h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r == 0);
+      //__VERIFIER_assert(h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r == 0);
+      //__VERIFIER_assert(h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r == 0);
+      //__VERIFIER_assert(p * p - n * q + q * r == 0);
+
+      //if (!(q != 1))
+      //    break;
+      if (4 * (q / 4) == q && 2 * (p / 2) == p) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+      }
+      }
+    }
+    //__VERIFIER_assert(h*h*h - 12*h*n + 16*n*p + 12*h*r - 16*p*r - h - 4*p == 0);
+    //__VERIFIER_assert(p*p - n + r == 0);
+    //__VERIFIER_assert(h*h*p - 4*h*n + 4*n*p + 4*h*r - 4*p*r - p == 0);
+    return 0;
+}

--- a/c/termination-nla/dijkstra4-both-nt.i
+++ b/c/termination-nla/dijkstra4-both-nt.i
@@ -1,0 +1,23 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int n, p, q, r, h;
+    n = __VERIFIER_nondet_int();
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    if (q > n) {
+    while (h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r == 0) {
+      if (4 * (q / 4) == q && 2 * (p / 2) == p) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+      }
+      }
+    }
+    return 0;
+}

--- a/c/termination-nla/dijkstra4-both-nt.yml
+++ b/c/termination-nla/dijkstra4-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'dijkstra4-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/dijkstra4-both-t.c
+++ b/c/termination-nla/dijkstra4-both-t.c
@@ -1,0 +1,64 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Compute the floor of the square root, by Dijkstra */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int n, p, q, r, h;
+
+    n = __VERIFIER_nondet_int();
+
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    int c = 0, k = __VERIFIER_nondet_int();
+    while ( q <= n ) {
+      // if (!(q <= n)) break;
+
+        q = 4 * q;
+    }
+    //q == 4^n
+
+    while (h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r + c <= k) {
+      //__VERIFIER_assert(r < 2 * p + q);
+      //__VERIFIER_assert(p*p + r*q == n*q);
+      //__VERIFIER_assert(h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r == 0);
+      //__VERIFIER_assert(h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r == 0);
+      //__VERIFIER_assert(h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r == 0);
+      //__VERIFIER_assert(p * p - n * q + q * r == 0);
+
+      //if (!(q != 1))
+      //    break;
+
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+        c++;
+    }
+    //__VERIFIER_assert(h*h*h - 12*h*n + 16*n*p + 12*h*r - 16*p*r - h - 4*p == 0);
+    //__VERIFIER_assert(p*p - n + r == 0);
+    //__VERIFIER_assert(h*h*p - 4*h*n + 4*n*p + 4*h*r - 4*p*r - p == 0);
+    return 0;
+}

--- a/c/termination-nla/dijkstra4-both-t.i
+++ b/c/termination-nla/dijkstra4-both-t.i
@@ -1,0 +1,24 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int n, p, q, r, h;
+    n = __VERIFIER_nondet_int();
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    int c = 0, k = __VERIFIER_nondet_int();
+    while ( q <= n ) {
+        q = 4 * q;
+    }
+    while (h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r + c <= k) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+        c++;
+    }
+    return 0;
+}

--- a/c/termination-nla/dijkstra4-both-t.yml
+++ b/c/termination-nla/dijkstra4-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'dijkstra4-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/dijkstra5-both-nt.c
+++ b/c/termination-nla/dijkstra5-both-nt.c
@@ -1,0 +1,68 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Compute the floor of the square root, by Dijkstra */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int n, p, q, r, h;
+
+    n = __VERIFIER_nondet_int();
+
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+
+    /*
+    while ( q <= n ) {
+      // if (!(q <= n)) break;
+
+        q = 4 * q;
+    }
+    //q == 4^n
+    */
+
+    if (q > n) {
+    while (h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r == 0) {
+      //__VERIFIER_assert(r < 2 * p + q);
+      //__VERIFIER_assert(p*p + r*q == n*q);
+      //__VERIFIER_assert(h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r == 0);
+      //__VERIFIER_assert(h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r == 0);
+      //__VERIFIER_assert(h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r == 0);
+      //__VERIFIER_assert(p * p - n * q + q * r == 0);
+
+      //if (!(q != 1))
+      //    break;
+      if (4 * (q / 4) == q && 2 * (p / 2) == p) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+      }
+      }
+    }
+    //__VERIFIER_assert(h*h*h - 12*h*n + 16*n*p + 12*h*r - 16*p*r - h - 4*p == 0);
+    //__VERIFIER_assert(p*p - n + r == 0);
+    //__VERIFIER_assert(h*h*p - 4*h*n + 4*n*p + 4*h*r - 4*p*r - p == 0);
+    return 0;
+}

--- a/c/termination-nla/dijkstra5-both-nt.i
+++ b/c/termination-nla/dijkstra5-both-nt.i
@@ -1,0 +1,23 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int n, p, q, r, h;
+    n = __VERIFIER_nondet_int();
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    if (q > n) {
+    while (h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r == 0) {
+      if (4 * (q / 4) == q && 2 * (p / 2) == p) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+      }
+      }
+    }
+    return 0;
+}

--- a/c/termination-nla/dijkstra5-both-nt.yml
+++ b/c/termination-nla/dijkstra5-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'dijkstra5-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/dijkstra5-both-t.c
+++ b/c/termination-nla/dijkstra5-both-t.c
@@ -1,0 +1,64 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Compute the floor of the square root, by Dijkstra */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int n, p, q, r, h;
+
+    n = __VERIFIER_nondet_int();
+
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    int c = 0, k = __VERIFIER_nondet_int();
+    while ( q <= n ) {
+      // if (!(q <= n)) break;
+
+        q = 4 * q;
+    }
+    //q == 4^n
+
+    while (h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r + c <= k) {
+      //__VERIFIER_assert(r < 2 * p + q);
+      //__VERIFIER_assert(p*p + r*q == n*q);
+      //__VERIFIER_assert(h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r == 0);
+      //__VERIFIER_assert(h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r == 0);
+      //__VERIFIER_assert(h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r == 0);
+      //__VERIFIER_assert(p * p - n * q + q * r == 0);
+
+      //if (!(q != 1))
+      //    break;
+
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+        c++;
+    }
+    //__VERIFIER_assert(h*h*h - 12*h*n + 16*n*p + 12*h*r - 16*p*r - h - 4*p == 0);
+    //__VERIFIER_assert(p*p - n + r == 0);
+    //__VERIFIER_assert(h*h*p - 4*h*n + 4*n*p + 4*h*r - 4*p*r - p == 0);
+    return 0;
+}

--- a/c/termination-nla/dijkstra5-both-t.i
+++ b/c/termination-nla/dijkstra5-both-t.i
@@ -1,0 +1,24 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int n, p, q, r, h;
+    n = __VERIFIER_nondet_int();
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    int c = 0, k = __VERIFIER_nondet_int();
+    while ( q <= n ) {
+        q = 4 * q;
+    }
+    while (h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r + c <= k) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+        c++;
+    }
+    return 0;
+}

--- a/c/termination-nla/dijkstra5-both-t.yml
+++ b/c/termination-nla/dijkstra5-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'dijkstra5-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/dijkstra6-both-nt.c
+++ b/c/termination-nla/dijkstra6-both-nt.c
@@ -1,0 +1,68 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Compute the floor of the square root, by Dijkstra */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int n, p, q, r, h;
+
+    n = __VERIFIER_nondet_int();
+
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+
+    /*
+    while ( q <= n ) {
+      // if (!(q <= n)) break;
+
+        q = 4 * q;
+    }
+    //q == 4^n
+    */
+
+    if (q > n) {
+    while (p * p - n * q + q * r == 0) {
+      //__VERIFIER_assert(r < 2 * p + q);
+      //__VERIFIER_assert(p*p + r*q == n*q);
+      //__VERIFIER_assert(h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r == 0);
+      //__VERIFIER_assert(h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r == 0);
+      //__VERIFIER_assert(h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r == 0);
+      //__VERIFIER_assert(p * p - n * q + q * r == 0);
+
+      //if (!(q != 1))
+      //    break;
+      if (4 * (q / 4) == q && 2 * (p / 2) == p) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+      }
+      }
+    }
+    //__VERIFIER_assert(h*h*h - 12*h*n + 16*n*p + 12*h*r - 16*p*r - h - 4*p == 0);
+    //__VERIFIER_assert(p*p - n + r == 0);
+    //__VERIFIER_assert(h*h*p - 4*h*n + 4*n*p + 4*h*r - 4*p*r - p == 0);
+    return 0;
+}

--- a/c/termination-nla/dijkstra6-both-nt.i
+++ b/c/termination-nla/dijkstra6-both-nt.i
@@ -1,0 +1,23 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int n, p, q, r, h;
+    n = __VERIFIER_nondet_int();
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    if (q > n) {
+    while (p * p - n * q + q * r == 0) {
+      if (4 * (q / 4) == q && 2 * (p / 2) == p) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+      }
+      }
+    }
+    return 0;
+}

--- a/c/termination-nla/dijkstra6-both-nt.yml
+++ b/c/termination-nla/dijkstra6-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'dijkstra6-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/dijkstra6-both-t.c
+++ b/c/termination-nla/dijkstra6-both-t.c
@@ -1,0 +1,64 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Compute the floor of the square root, by Dijkstra */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern int __VERIFIER_nondet_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int n, p, q, r, h;
+
+    n = __VERIFIER_nondet_int();
+
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    int c = 0, k = __VERIFIER_nondet_int();
+    while ( q <= n ) {
+      // if (!(q <= n)) break;
+
+        q = 4 * q;
+    }
+    //q == 4^n
+
+    while (p * p - n * q + q * r + c <= k) {
+      //__VERIFIER_assert(r < 2 * p + q);
+      //__VERIFIER_assert(p*p + r*q == n*q);
+      //__VERIFIER_assert(h * h * h - 12 * h * n * q + 16 * n * p * q - h * q * q - 4 * p * q * q + 12 * h * q * r - 16 * p * q * r == 0);
+      //__VERIFIER_assert(h * h * n - 4 * h * n * p + 4 * (n * n) * q - n * q * q - h * h * r + 4 * h * p * r - 8 * n * q * r + q * q * r + 4 * q * r * r == 0);
+      //__VERIFIER_assert(h * h * p - 4 * h * n * q + 4 * n * p * q - p * q * q + 4 * h * q * r - 4 * p * q * r == 0);
+      //__VERIFIER_assert(p * p - n * q + q * r == 0);
+
+      //if (!(q != 1))
+      //    break;
+
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+        c++;
+    }
+    //__VERIFIER_assert(h*h*h - 12*h*n + 16*n*p + 12*h*r - 16*p*r - h - 4*p == 0);
+    //__VERIFIER_assert(p*p - n + r == 0);
+    //__VERIFIER_assert(h*h*p - 4*h*n + 4*n*p + 4*h*r - 4*p*r - p == 0);
+    return 0;
+}

--- a/c/termination-nla/dijkstra6-both-t.i
+++ b/c/termination-nla/dijkstra6-both-t.i
@@ -1,0 +1,24 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int n, p, q, r, h;
+    n = __VERIFIER_nondet_int();
+    p = 0;
+    q = 1;
+    r = n;
+    h = 0;
+    int c = 0, k = __VERIFIER_nondet_int();
+    while ( q <= n ) {
+        q = 4 * q;
+    }
+    while (p * p - n * q + q * r + c <= k) {
+        q = q / 4;
+        h = p + q;
+        p = p / 2;
+        if (r >= h) {
+            p = p + q;
+            r = r - h;
+        }
+        c++;
+    }
+    return 0;
+}

--- a/c/termination-nla/dijkstra6-both-t.yml
+++ b/c/termination-nla/dijkstra6-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'dijkstra6-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/divbin1-both-nt.c
+++ b/c/termination-nla/divbin1-both-nt.c
@@ -1,0 +1,66 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+  A division algorithm, by Kaldewaij
+  returns A//B
+*/
+
+#include <limits.h>
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+    }*/
+
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+int main() {
+  unsigned A, B;
+  unsigned q, r, b;
+  A = __VERIFIER_nondet_unsigned_int();
+  B = __VERIFIER_nondet_unsigned_int();
+  //__VERIFIER_assume(B < UINT_MAX/2);
+  if (B >= UINT_MAX/2) return 0;
+  //__VERIFIER_assume(B >= 1);
+  if ( B < 1 ) return 0;
+
+  if (A >= UINT_MAX/2) return 0;
+
+    q = 0;
+    r = A;
+    b = B;
+    /*
+    while (r >= b) {
+      //if (!(r >= b)) break;
+      b = 2 * b;
+    }
+    */
+    if (r < b) {
+    while (A == q * b + r) {
+      // __VERIFIER_assert(A == q * b + r);
+        //if (!(b != B)) break;
+
+        if (2 * (b / 2) == b) {
+            q = 2 * q;
+            b = b / 2;
+            if (r >= b) {
+                q = q + 1;
+                r = r - b;
+            }
+        }
+    }
+    }
+    //__VERIFIER_assert(A == q * b + r);
+    return 0;
+}

--- a/c/termination-nla/divbin1-both-nt.i
+++ b/c/termination-nla/divbin1-both-nt.i
@@ -1,0 +1,27 @@
+extern int __VERIFIER_nondet_int(void);
+extern unsigned int __VERIFIER_nondet_unsigned_int(void);
+int main() {
+  unsigned A, B;
+  unsigned q, r, b;
+  A = __VERIFIER_nondet_unsigned_int();
+  B = __VERIFIER_nondet_unsigned_int();
+  if (B >= (0x7fffffff * 2U + 1U)/2) return 0;
+  if ( B < 1 ) return 0;
+  if (A >= (0x7fffffff * 2U + 1U)/2) return 0;
+    q = 0;
+    r = A;
+    b = B;
+    if (r < b) {
+    while (A == q * b + r) {
+        if (2 * (b / 2) == b) {
+            q = 2 * q;
+            b = b / 2;
+            if (r >= b) {
+                q = q + 1;
+                r = r - b;
+            }
+        }
+    }
+    }
+    return 0;
+}

--- a/c/termination-nla/divbin1-both-nt.yml
+++ b/c/termination-nla/divbin1-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'divbin1-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/divbin1-both-t.c
+++ b/c/termination-nla/divbin1-both-t.c
@@ -1,0 +1,66 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+  A division algorithm, by Kaldewaij
+  returns A//B
+*/
+
+#include <limits.h>
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+    }*/
+
+extern int __VERIFIER_nondet_int(void);
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+
+int main() {
+  unsigned A, B;
+  unsigned q, r, b;
+  int c = 0, k = __VERIFIER_nondet_int();
+  A = __VERIFIER_nondet_unsigned_int();
+  B = __VERIFIER_nondet_unsigned_int();
+  //__VERIFIER_assume(B < UINT_MAX/2);
+  if (B >= UINT_MAX/2) return 0;
+  //__VERIFIER_assume(B >= 1);
+  if ( B < 1 ) return 0;
+
+  if (A >= UINT_MAX/2) return 0;
+
+    q = 0;
+    r = A;
+    b = B;
+
+    while (r >= b) {
+      //if (!(r >= b)) break;
+      b = 2 * b;
+    }
+
+    while (q * b + r - A + c <=k) {
+      // __VERIFIER_assert(A == q * b + r);
+        //if (!(b != B)) break;
+
+        q = 2 * q;
+        b = b / 2;
+        if (r >= b) {
+            q = q + 1;
+            r = r - b;
+        }
+        c++;
+    }
+
+    //__VERIFIER_assert(A == q * b + r);
+    return 0;
+}

--- a/c/termination-nla/divbin1-both-t.i
+++ b/c/termination-nla/divbin1-both-t.i
@@ -1,0 +1,28 @@
+extern int __VERIFIER_nondet_int(void);
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+int main() {
+  unsigned A, B;
+  unsigned q, r, b;
+  int c = 0, k = __VERIFIER_nondet_int();
+  A = __VERIFIER_nondet_unsigned_int();
+  B = __VERIFIER_nondet_unsigned_int();
+  if (B >= (0x7fffffff * 2U + 1U)/2) return 0;
+  if ( B < 1 ) return 0;
+  if (A >= (0x7fffffff * 2U + 1U)/2) return 0;
+    q = 0;
+    r = A;
+    b = B;
+    while (r >= b) {
+      b = 2 * b;
+    }
+    while (q * b + r - A + c <=k) {
+        q = 2 * q;
+        b = b / 2;
+        if (r >= b) {
+            q = q + 1;
+            r = r - b;
+        }
+        c++;
+    }
+    return 0;
+}

--- a/c/termination-nla/divbin1-both-t.yml
+++ b/c/termination-nla/divbin1-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'divbin1-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/egcd-both-nt.c
+++ b/c/termination-nla/egcd-both-nt.c
@@ -1,0 +1,48 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* extended Euclid's algorithm */
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, b, p, q, r, s;
+    int x, y;
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    //assume_abort_if_not(x >= 1);
+    //assume_abort_if_not(y >= 1);
+    if (x>=1 && y>=1) {
+        a = x;
+        b = y;
+        p = 1;
+        q = 0;
+        r = 0;
+        s = 1;
+
+        while (b == x * q + y * s) {
+            //__VERIFIER_assert(1 == p * s - r * q);
+            //__VERIFIER_assert(a == y * r + x * p);
+            //__VERIFIER_assert(b == x * q + y * s);
+
+            if (a > b) {
+                a = a - b;
+                p = p - q;
+                r = r - s;
+            } else {
+                b = b - a;
+                q = q - p;
+                s = s - r;
+            }
+        }
+    
+    	//__VERIFIER_assert(a - b == 0);    
+    	//__VERIFIER_assert(p*x + r*y - b == 0);
+    	//__VERIFIER_assert(q*r - p*s + 1 == 0);
+    	//__VERIFIER_assert(q*x + s*y - b == 0);
+    }
+    return 0;
+}

--- a/c/termination-nla/egcd-both-nt.i
+++ b/c/termination-nla/egcd-both-nt.i
@@ -1,0 +1,27 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, b, p, q, r, s;
+    int x, y;
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    if (x>=1 && y>=1) {
+        a = x;
+        b = y;
+        p = 1;
+        q = 0;
+        r = 0;
+        s = 1;
+        while (b == x * q + y * s) {
+            if (a > b) {
+                a = a - b;
+                p = p - q;
+                r = r - s;
+            } else {
+                b = b - a;
+                q = q - p;
+                s = s - r;
+            }
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/egcd-both-nt.yml
+++ b/c/termination-nla/egcd-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'egcd-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/egcd-both-t.c
+++ b/c/termination-nla/egcd-both-t.c
@@ -1,0 +1,48 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* extended Euclid's algorithm */
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, b, p, q, r, s;
+    int x, y;
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    //assume_abort_if_not(x >= 1);
+    //assume_abort_if_not(y >= 1);
+    if (x>=1 && y>=1) {
+        a = x;
+        b = y;
+        p = 1;
+        q = 0;
+        r = 0;
+        s = 1;
+
+        while (y * r + x * p != x * q + y * s) {
+            //__VERIFIER_assert(1 == p * s - r * q);
+            //__VERIFIER_assert(a == y * r + x * p);
+            //__VERIFIER_assert(b == x * q + y * s);
+
+            if (a > b) {
+                a = a - b;
+                p = p - q;
+                r = r - s;
+            } else {
+                b = b - a;
+                q = q - p;
+                s = s - r;
+            }
+        }
+    
+    	//__VERIFIER_assert(a - b == 0);    
+    	//__VERIFIER_assert(p*x + r*y - b == 0);
+    	//__VERIFIER_assert(q*r - p*s + 1 == 0);
+    	//__VERIFIER_assert(q*x + s*y - b == 0);
+    }
+    return 0;
+}

--- a/c/termination-nla/egcd-both-t.i
+++ b/c/termination-nla/egcd-both-t.i
@@ -1,0 +1,27 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, b, p, q, r, s;
+    int x, y;
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    if (x>=1 && y>=1) {
+        a = x;
+        b = y;
+        p = 1;
+        q = 0;
+        r = 0;
+        s = 1;
+        while (y * r + x * p != x * q + y * s) {
+            if (a > b) {
+                a = a - b;
+                p = p - q;
+                r = r - s;
+            } else {
+                b = b - a;
+                q = q - p;
+                s = s - r;
+            }
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/egcd-both-t.yml
+++ b/c/termination-nla/egcd-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'egcd-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/egcd2-both-nt.c
+++ b/c/termination-nla/egcd2-both-nt.c
@@ -1,0 +1,65 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* extended Euclid's algorithm */
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int x, y;
+    int a, b, p, q, r, s, c, k;
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    //assume_abort_if_not(x >= 1);
+    //assume_abort_if_not(y >= 1);
+    if (x<1) {
+        return x;
+    }
+    if (y < 1) {
+        return x;
+    }
+
+
+    a = x;
+    b = y;
+    p = 1;
+    q = 0;
+    r = 0;
+    s = 1;
+    c = 0;
+    k = 0;
+    while (1) {
+        if (!(b != 0))
+            break;
+        c = a;
+        k = 0;
+
+        while (a == y*r + x*p) {
+            //__VERIFIER_assert(a == k * b + c);
+            //__VERIFIER_assert(a == y*r + x*p);
+            //__VERIFIER_assert(b == x * q + y * s);
+	    //__VERIFIER_assert(q*x*y + s*y*y - q*x - b*y - s*y + b == 0);
+            c = c - b;
+            k = k + 1;
+        }
+
+        a = b;
+        b = c;
+
+        int temp;
+        temp = p;
+        p = q;
+        q = temp - q * k;
+        temp = r;
+        r = s;
+        s = temp - s * k;
+    }
+    
+
+    //__VERIFIER_assert(q*x + s*y == 0);
+    //__VERIFIER_assert(p*x + r*y == a);
+    return a;
+}

--- a/c/termination-nla/egcd2-both-nt.i
+++ b/c/termination-nla/egcd2-both-nt.i
@@ -1,0 +1,41 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int x, y;
+    int a, b, p, q, r, s, c, k;
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    if (x<1) {
+        return x;
+    }
+    if (y < 1) {
+        return x;
+    }
+    a = x;
+    b = y;
+    p = 1;
+    q = 0;
+    r = 0;
+    s = 1;
+    c = 0;
+    k = 0;
+    while (1) {
+        if (!(b != 0))
+            break;
+        c = a;
+        k = 0;
+        while (a == y*r + x*p) {
+            c = c - b;
+            k = k + 1;
+        }
+        a = b;
+        b = c;
+        int temp;
+        temp = p;
+        p = q;
+        q = temp - q * k;
+        temp = r;
+        r = s;
+        s = temp - s * k;
+    }
+    return a;
+}

--- a/c/termination-nla/egcd2-both-nt.yml
+++ b/c/termination-nla/egcd2-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'egcd2-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/egcd2-both-t.c
+++ b/c/termination-nla/egcd2-both-t.c
@@ -1,0 +1,64 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* extended Euclid's algorithm */
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int x, y;
+    int a, b, p, q, r, s, c, k;
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    //assume_abort_if_not(x >= 1);
+    if (x<1) {
+	return x;
+    }
+    //assume_abort_if_not(y >= 1);
+    if (y < 1) {
+	return x;
+    }
+
+    a = x;
+    b = y;
+    p = 1;
+    q = 0;
+    r = 0;
+    s = 1;
+    c = 0;
+    k = 0;
+    while (1) {
+        if (!(b != 0))
+            break;
+        c = a;
+        k = 0;
+
+        while (c >= x * q + y * s) {
+            //__VERIFIER_assert(a == k * b + c);
+            //__VERIFIER_assert(a == y*r + x*p);
+            //__VERIFIER_assert(b == x * q + y * s);
+	    //__VERIFIER_assert(q*x*y + s*y*y - q*x - b*y - s*y + b == 0);
+            c = c - b;
+            k = k + 1;
+        }
+
+        a = b;
+        b = c;
+
+        int temp;
+        temp = p;
+        p = q;
+        q = temp - q * k;
+        temp = r;
+        r = s;
+        s = temp - s * k;
+    }
+    
+
+    //__VERIFIER_assert(q*x + s*y == 0);
+    //__VERIFIER_assert(p*x + r*y == a);
+    return a;
+}

--- a/c/termination-nla/egcd2-both-t.i
+++ b/c/termination-nla/egcd2-both-t.i
@@ -1,0 +1,41 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int x, y;
+    int a, b, p, q, r, s, c, k;
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    if (x<1) {
+ return x;
+    }
+    if (y < 1) {
+ return x;
+    }
+    a = x;
+    b = y;
+    p = 1;
+    q = 0;
+    r = 0;
+    s = 1;
+    c = 0;
+    k = 0;
+    while (1) {
+        if (!(b != 0))
+            break;
+        c = a;
+        k = 0;
+        while (c >= x * q + y * s) {
+            c = c - b;
+            k = k + 1;
+        }
+        a = b;
+        b = c;
+        int temp;
+        temp = p;
+        p = q;
+        q = temp - q * k;
+        temp = r;
+        r = s;
+        s = temp - s * k;
+    }
+    return a;
+}

--- a/c/termination-nla/egcd2-both-t.yml
+++ b/c/termination-nla/egcd2-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'egcd2-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/egcd3-both-nt.c
+++ b/c/termination-nla/egcd3-both-nt.c
@@ -1,0 +1,67 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* extended Euclid's algorithm */
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int x, y;
+    int a, b, p, q, r, s;
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    //assume_abort_if_not(x >= 1);
+    //assume_abort_if_not(y >= 1);
+
+    a = x;
+    b = y;
+    p = 1;
+    q = 0;
+    r = 0;
+    s = 1;
+
+    while (1) {
+        if (!(b != 0))
+            break;
+        int c, k;
+        c = a;
+        k = 0;
+
+        while (1) {
+            if (!(c >= b))
+                break;
+            int d, v;
+            d = 1;
+            v = b;
+
+            while (1) {
+                //__VERIFIER_assert(a == y * r + x * p);
+                //__VERIFIER_assert(b == x * q + y * s);
+                //__VERIFIER_assert(a == k * b + c);
+                //__VERIFIER_assert(v == b * d);
+
+                if (!(b == x * q + y * s))
+                    break;
+                d = 2 * d;
+                v = 2 * v;
+            }
+            c = c - v;
+            k = k + d;
+        }
+
+        a = b;
+        b = c;
+        int temp;
+        temp = p;
+        p = q;
+        q = temp - q * k;
+        temp = r;
+        r = s;
+        s = temp - s * k;
+    }
+    //__VERIFIER_assert(p*x - q*x + r*y - s*y  == a);
+    return 0;
+}

--- a/c/termination-nla/egcd3-both-nt.i
+++ b/c/termination-nla/egcd3-both-nt.i
@@ -1,0 +1,45 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int x, y;
+    int a, b, p, q, r, s;
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    a = x;
+    b = y;
+    p = 1;
+    q = 0;
+    r = 0;
+    s = 1;
+    while (1) {
+        if (!(b != 0))
+            break;
+        int c, k;
+        c = a;
+        k = 0;
+        while (1) {
+            if (!(c >= b))
+                break;
+            int d, v;
+            d = 1;
+            v = b;
+            while (1) {
+                if (!(b == x * q + y * s))
+                    break;
+                d = 2 * d;
+                v = 2 * v;
+            }
+            c = c - v;
+            k = k + d;
+        }
+        a = b;
+        b = c;
+        int temp;
+        temp = p;
+        p = q;
+        q = temp - q * k;
+        temp = r;
+        r = s;
+        s = temp - s * k;
+    }
+    return 0;
+}

--- a/c/termination-nla/egcd3-both-nt.yml
+++ b/c/termination-nla/egcd3-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'egcd3-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/egcd3-both-t.c
+++ b/c/termination-nla/egcd3-both-t.c
@@ -1,0 +1,67 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* extended Euclid's algorithm */
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int x, y;
+    int a, b, p, q, r, s;
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    //assume_abort_if_not(x >= 1);
+    //assume_abort_if_not(y >= 1);
+
+    a = x;
+    b = y;
+    p = 1;
+    q = 0;
+    r = 0;
+    s = 1;
+
+    while (1) {
+        if (!(b != 0))
+            break;
+        int c, k;
+        c = a;
+        k = 0;
+
+        while (1) {
+            if (!(c >= b))
+                break;
+            int d, v;
+            d = 1;
+            v = b;
+
+            while (1) {
+                //__VERIFIER_assert(a == y * r + x * p);
+                //__VERIFIER_assert(b == x * q + y * s);
+                //__VERIFIER_assert(a == k * b + c);
+                //__VERIFIER_assert(v == b * d);
+
+                if (!(c >= 2 * b * d))
+                    break;
+                d = 2 * d;
+                v = 2 * v;
+            }
+            c = c - v;
+            k = k + d;
+        }
+
+        a = b;
+        b = c;
+        int temp;
+        temp = p;
+        p = q;
+        q = temp - q * k;
+        temp = r;
+        r = s;
+        s = temp - s * k;
+    }
+    //__VERIFIER_assert(p*x - q*x + r*y - s*y  == a);
+    return 0;
+}

--- a/c/termination-nla/egcd3-both-t.i
+++ b/c/termination-nla/egcd3-both-t.i
@@ -1,0 +1,45 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int x, y;
+    int a, b, p, q, r, s;
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    a = x;
+    b = y;
+    p = 1;
+    q = 0;
+    r = 0;
+    s = 1;
+    while (1) {
+        if (!(b != 0))
+            break;
+        int c, k;
+        c = a;
+        k = 0;
+        while (1) {
+            if (!(c >= b))
+                break;
+            int d, v;
+            d = 1;
+            v = b;
+            while (1) {
+                if (!(c >= 2 * b * d))
+                    break;
+                d = 2 * d;
+                v = 2 * v;
+            }
+            c = c - v;
+            k = k + d;
+        }
+        a = b;
+        b = c;
+        int temp;
+        temp = p;
+        p = q;
+        q = temp - q * k;
+        temp = r;
+        r = s;
+        s = temp - s * k;
+    }
+    return 0;
+}

--- a/c/termination-nla/egcd3-both-t.yml
+++ b/c/termination-nla/egcd3-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'egcd3-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/fermat1-both-nt.c
+++ b/c/termination-nla/fermat1-both-nt.c
@@ -1,0 +1,63 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern double __VERIFIER_nondet_double(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int A, R;
+    int u, v, r;
+    A = __VERIFIER_nondet_int();
+    R = __VERIFIER_nondet_int();
+    //__VERIFIER_assume((R - 1) * (R - 1) < A);
+    if ((R - 1) * (R - 1) >= A) return 0;
+    //__VERIFIER_assume(A <= R * R);
+    //__VERIFIER_assume(A % 2 == 1);
+    if (A % 2 != 1) return 0;
+
+    u = 2 * R + 1;
+    v = 1;
+    r = R * R - A;
+
+
+    while (4*(A+r) == u*u - v*v - 2*u + 2*v) {
+      //__VERIFIER_assert(4*(A+r) == u*u - v*v - 2*u + 2*v);
+      //if (!(r != 0)) break;
+
+      int c = 0, k = __VERIFIER_nondet_int();
+        //while (u*u - v*v - 2*u + 2*v - 4*(A+r) + c <= k) {
+          //__VERIFIER_assert(4*(A+r) == u*u - v*v - 2*u + 2*v);
+          //if (!(r > 0)) break;
+            r = r - v;
+            v = v + 2;
+            c++;
+        //}
+
+        //while (4*(A+r) - u*u - v*v - 2*u + 2*v + c <= k) {
+          //__VERIFIER_assert(4*(A+r) == u*u - v*v - 2*u + 2*v);
+          //if (!(r < 0))    break;
+            r = r + u;
+            u = u + 2;
+            c++;
+        //}
+    }
+
+    //__VERIFIER_assert(4*A == u*u - v*v  - 2*u + 2*v);
+    return 0;
+}

--- a/c/termination-nla/fermat1-both-nt.i
+++ b/c/termination-nla/fermat1-both-nt.i
@@ -1,0 +1,22 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int A, R;
+    int u, v, r;
+    A = __VERIFIER_nondet_int();
+    R = __VERIFIER_nondet_int();
+    if ((R - 1) * (R - 1) >= A) return 0;
+    if (A % 2 != 1) return 0;
+    u = 2 * R + 1;
+    v = 1;
+    r = R * R - A;
+    while (4*(A+r) == u*u - v*v - 2*u + 2*v) {
+      int c = 0, k = __VERIFIER_nondet_int();
+            r = r - v;
+            v = v + 2;
+            c++;
+            r = r + u;
+            u = u + 2;
+            c++;
+    }
+    return 0;
+}

--- a/c/termination-nla/fermat1-both-nt.yml
+++ b/c/termination-nla/fermat1-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'fermat1-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/fermat1-both-t.c
+++ b/c/termination-nla/fermat1-both-t.c
@@ -1,0 +1,64 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern double __VERIFIER_nondet_double(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int A, R;
+    int u, v, r;
+    A = __VERIFIER_nondet_int();
+    R = __VERIFIER_nondet_int();
+    //__VERIFIER_assume((R - 1) * (R - 1) < A);
+    if ((R - 1) * (R - 1) >= A) return 0;
+    //__VERIFIER_assume(A <= R * R);
+    //__VERIFIER_assume(A % 2 == 1);
+    if (A % 2 != 1) return 0;
+
+    u = 2 * R + 1;
+    v = 1;
+    r = R * R - A;
+
+
+    int cc = 0, kk = __VERIFIER_nondet_int();
+    while (u*u - v*v - 2*u + 2*v - 4*(A+r) + cc < kk) {
+      //__VERIFIER_assert(4*(A+r) == u*u - v*v - 2*u + 2*v);
+      //if (!(r != 0)) break;
+
+      int c = 0, k = __VERIFIER_nondet_int();
+        while (u*u - v*v - 2*u + 2*v - 4*(A+r) + c <= k) {
+          //__VERIFIER_assert(4*(A+r) == u*u - v*v - 2*u + 2*v);
+          //if (!(r > 0)) break;
+            r = r - v;
+            v = v + 2;
+            c++;
+        }
+
+        while (4*(A+r) - u*u - v*v - 2*u + 2*v + c <= k) {
+          //__VERIFIER_assert(4*(A+r) == u*u - v*v - 2*u + 2*v);
+          //if (!(r < 0))    break;
+            r = r + u;
+            u = u + 2;
+            c++;
+        }
+    }
+
+    //__VERIFIER_assert(4*A == u*u - v*v  - 2*u + 2*v);
+    return 0;
+}

--- a/c/termination-nla/fermat1-both-t.i
+++ b/c/termination-nla/fermat1-both-t.i
@@ -1,0 +1,27 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int A, R;
+    int u, v, r;
+    A = __VERIFIER_nondet_int();
+    R = __VERIFIER_nondet_int();
+    if ((R - 1) * (R - 1) >= A) return 0;
+    if (A % 2 != 1) return 0;
+    u = 2 * R + 1;
+    v = 1;
+    r = R * R - A;
+    int cc = 0, kk = __VERIFIER_nondet_int();
+    while (u*u - v*v - 2*u + 2*v - 4*(A+r) + cc < kk) {
+      int c = 0, k = __VERIFIER_nondet_int();
+        while (u*u - v*v - 2*u + 2*v - 4*(A+r) + c <= k) {
+            r = r - v;
+            v = v + 2;
+            c++;
+        }
+        while (4*(A+r) - u*u - v*v - 2*u + 2*v + c <= k) {
+            r = r + u;
+            u = u + 2;
+            c++;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/fermat1-both-t.yml
+++ b/c/termination-nla/fermat1-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'fermat1-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/fermat2-both-nt.c
+++ b/c/termination-nla/fermat2-both-nt.c
@@ -1,0 +1,65 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern double __VERIFIER_nondet_double(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int A, R;
+    int u, v, r;
+    A = __VERIFIER_nondet_int();
+    R = __VERIFIER_nondet_int();
+    //__VERIFIER_assume((R - 1) * (R - 1) < A);
+    if ((R - 1) * (R - 1) >= A) return 0;
+    //__VERIFIER_assume(A <= R * R);
+    //__VERIFIER_assume(A % 2 == 1);
+    if (A % 2 != 1) return 0;
+
+    u = 2 * R + 1;
+    v = 1;
+    r = R * R - A;
+
+
+    int cc = 0, kk = __VERIFIER_nondet_int();
+    while (u*u - v*v - 2*u + 2*v - 4*(A+r) + cc < kk) {
+      //__VERIFIER_assert(4*(A+r) == u*u - v*v - 2*u + 2*v);
+      //if (!(r != 0)) break;
+
+      int c = 0, k = __VERIFIER_nondet_int();
+        while (4*(A+r) == u*u - v*v - 2*u + 2*v) {
+          //__VERIFIER_assert(4*(A+r) == u*u - v*v - 2*u + 2*v);
+          //if (!(r > 0)) break;
+            r = r - v;
+            v = v + 2;
+        }
+
+        while (4*(A+r) - u*u - v*v - 2*u + 2*v + c <= k) {
+          //__VERIFIER_assert(4*(A+r) == u*u - v*v - 2*u + 2*v);
+          //if (!(r < 0))    break;
+            r = r + u;
+            u = u + 2;
+            c++;
+        }
+
+        cc++;
+    }
+
+    //__VERIFIER_assert(4*A == u*u - v*v  - 2*u + 2*v);
+    return 0;
+}

--- a/c/termination-nla/fermat2-both-nt.i
+++ b/c/termination-nla/fermat2-both-nt.i
@@ -1,0 +1,27 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int A, R;
+    int u, v, r;
+    A = __VERIFIER_nondet_int();
+    R = __VERIFIER_nondet_int();
+    if ((R - 1) * (R - 1) >= A) return 0;
+    if (A % 2 != 1) return 0;
+    u = 2 * R + 1;
+    v = 1;
+    r = R * R - A;
+    int cc = 0, kk = __VERIFIER_nondet_int();
+    while (u*u - v*v - 2*u + 2*v - 4*(A+r) + cc < kk) {
+      int c = 0, k = __VERIFIER_nondet_int();
+        while (4*(A+r) == u*u - v*v - 2*u + 2*v) {
+            r = r - v;
+            v = v + 2;
+        }
+        while (4*(A+r) - u*u - v*v - 2*u + 2*v + c <= k) {
+            r = r + u;
+            u = u + 2;
+            c++;
+        }
+        cc++;
+    }
+    return 0;
+}

--- a/c/termination-nla/fermat2-both-nt.yml
+++ b/c/termination-nla/fermat2-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'fermat2-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/fermat3-both-nt.c
+++ b/c/termination-nla/fermat3-both-nt.c
@@ -1,0 +1,65 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* program computing a divisor for factorisation, by Knuth 4.5.4 Alg C ? */
+/*
+extern void __VERIFIER_error() __attribute__((__noreturn__));
+extern double __VERIFIER_nondet_double(void);
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int A, R;
+    int u, v, r;
+    A = __VERIFIER_nondet_int();
+    R = __VERIFIER_nondet_int();
+    //__VERIFIER_assume((R - 1) * (R - 1) < A);
+    if ((R - 1) * (R - 1) >= A) return 0;
+    //__VERIFIER_assume(A <= R * R);
+    //__VERIFIER_assume(A % 2 == 1);
+    if (A % 2 != 1) return 0;
+
+    u = 2 * R + 1;
+    v = 1;
+    r = R * R - A;
+
+
+    int cc = 0, kk = __VERIFIER_nondet_int();
+    while (u*u - v*v - 2*u + 2*v - 4*(A+r) + cc < kk) {
+      //__VERIFIER_assert(4*(A+r) == u*u - v*v - 2*u + 2*v);
+      //if (!(r != 0)) break;
+
+      int c = 0, k = __VERIFIER_nondet_int();
+        //while (u*u - v*v - 2*u + 2*v - 4*(A+r) + c <= k) {
+          //__VERIFIER_assert(4*(A+r) == u*u - v*v - 2*u + 2*v);
+          //if (!(r > 0)) break;
+            r = r - v;
+            v = v + 2;
+            c++;
+        //}
+
+        while (4*(A+r) == u*u - v*v - 2*u + 2*v) {
+          //__VERIFIER_assert(4*(A+r) == u*u - v*v - 2*u + 2*v);
+          //if (!(r < 0))    break;
+            r = r + u;
+            u = u + 2;
+        }
+
+        cc++;
+    }
+
+    //__VERIFIER_assert(4*A == u*u - v*v  - 2*u + 2*v);
+    return 0;
+}

--- a/c/termination-nla/fermat3-both-nt.i
+++ b/c/termination-nla/fermat3-both-nt.i
@@ -1,0 +1,25 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int A, R;
+    int u, v, r;
+    A = __VERIFIER_nondet_int();
+    R = __VERIFIER_nondet_int();
+    if ((R - 1) * (R - 1) >= A) return 0;
+    if (A % 2 != 1) return 0;
+    u = 2 * R + 1;
+    v = 1;
+    r = R * R - A;
+    int cc = 0, kk = __VERIFIER_nondet_int();
+    while (u*u - v*v - 2*u + 2*v - 4*(A+r) + cc < kk) {
+      int c = 0, k = __VERIFIER_nondet_int();
+            r = r - v;
+            v = v + 2;
+            c++;
+        while (4*(A+r) == u*u - v*v - 2*u + 2*v) {
+            r = r + u;
+            u = u + 2;
+        }
+        cc++;
+    }
+    return 0;
+}

--- a/c/termination-nla/fermat3-both-nt.yml
+++ b/c/termination-nla/fermat3-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'fermat3-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/freire1-both-nt.c
+++ b/c/termination-nla/freire1-both-nt.c
@@ -1,0 +1,48 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Algorithm for finding the closest integer to square root,
+ * more details, see : http://www.pedrofreire.com/sqrt/sqrt1.en.html 
+
+Note: for some reason using cpa was able to disprove these
+cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
+*/
+
+//extern void __VERIFIER_error() __attribute__((__noreturn__));
+//extern int __VERIFIER_nondet_int(void);
+/*
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int r;
+    //double a, x;
+    int x;
+    int a = 2 * __VERIFIER_nondet_int();
+    x = a / 2;
+    r = 0;
+    
+    while ( r*r - a - r + 2*x == 0 ) {
+      //__VERIFIER_assert((int)(r*r - a - r + 2*x) == 0);
+
+      //if (!(x > r))             break;
+        x = x - r;
+        r = r + 1;
+    }
+
+    //__VERIFIER_assert((int)(r*r - a - r + 2*x) == 0);
+    return 0;
+}

--- a/c/termination-nla/freire1-both-nt.i
+++ b/c/termination-nla/freire1-both-nt.i
@@ -1,0 +1,13 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int r;
+    int x;
+    int a = 2 * __VERIFIER_nondet_int();
+    x = a / 2;
+    r = 0;
+    while ( r*r - a - r + 2*x == 0 ) {
+        x = x - r;
+        r = r + 1;
+    }
+    return 0;
+}

--- a/c/termination-nla/freire1-both-nt.yml
+++ b/c/termination-nla/freire1-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'freire1-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/freire1-both-t.c
+++ b/c/termination-nla/freire1-both-t.c
@@ -1,0 +1,49 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Algorithm for finding the closest integer to square root,
+ * more details, see : http://www.pedrofreire.com/sqrt/sqrt1.en.html 
+
+Note: for some reason using cpa was able to disprove these
+cpa.sh -kInduction -setprop solver.solver=z3 freire1.c
+*/
+
+//extern void __VERIFIER_error() __attribute__((__noreturn__));
+//extern int __VERIFIER_nondet_int(void);
+/*
+extern void __VERIFIER_assume(int expression);
+void __VERIFIER_assert(int cond) {
+    if (!(cond)) {
+    ERROR:
+        __VERIFIER_error();
+    }
+    return;
+}
+*/
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int r;
+    //double a, x;
+    int x;
+    int a = __VERIFIER_nondet_int();
+    x = a / 2;
+    r = 0;
+    int c = 0; int k = __VERIFIER_nondet_int(); // Added
+    
+    while ( r*r - a - r + 2*x + c <= k ) {
+      //__VERIFIER_assert((int)(r*r - a - r + 2*x) == 0);
+
+      //if (!(x > r))             break;
+        x = x - r;
+        r = r + 1;
+    }
+
+    //__VERIFIER_assert((int)(r*r - a - r + 2*x) == 0);
+    return 0;
+}

--- a/c/termination-nla/freire1-both-t.i
+++ b/c/termination-nla/freire1-both-t.i
@@ -1,0 +1,14 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int r;
+    int x;
+    int a = __VERIFIER_nondet_int();
+    x = a / 2;
+    r = 0;
+    int c = 0; int k = __VERIFIER_nondet_int();
+    while ( r*r - a - r + 2*x + c <= k ) {
+        x = x - r;
+        r = r + 1;
+    }
+    return 0;
+}

--- a/c/termination-nla/freire1-both-t.yml
+++ b/c/termination-nla/freire1-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'freire1-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/geo1-both-nt.c
+++ b/c/termination-nla/geo1-both-nt.c
@@ -1,0 +1,41 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* 
+Geometric Series
+computes x=(z-1)* sum(z^k)[k=0..k-1] , y = z^k
+returns 1+x-y == 0
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int z, k;
+    int x, y, c;
+    z = __VERIFIER_nondet_int();
+    k = __VERIFIER_nondet_int();
+
+    x = 1;
+    y = z;
+    c = 1;
+
+    while (1) {
+        //__VERIFIER_assert(x*z - x - y + 1 == 0);
+
+        if (!(x*z - x - y + 1 == 0)) 
+            break;
+
+        c = c + 1;
+        x = x * z + 1;
+        y = y * z;
+
+    }  //geo1
+
+    x = x * (z - 1);
+
+    //__VERIFIER_assert(1 + x - y == 0);
+    return 0;
+}

--- a/c/termination-nla/geo1-both-nt.i
+++ b/c/termination-nla/geo1-both-nt.i
@@ -1,0 +1,19 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int z, k;
+    int x, y, c;
+    z = __VERIFIER_nondet_int();
+    k = __VERIFIER_nondet_int();
+    x = 1;
+    y = z;
+    c = 1;
+    while (1) {
+        if (!(x*z - x - y + 1 == 0))
+            break;
+        c = c + 1;
+        x = x * z + 1;
+        y = y * z;
+    }
+    x = x * (z - 1);
+    return 0;
+}

--- a/c/termination-nla/geo1-both-nt.yml
+++ b/c/termination-nla/geo1-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'geo1-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/geo1-both-t.c
+++ b/c/termination-nla/geo1-both-t.c
@@ -1,0 +1,41 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* 
+Geometric Series
+computes x=(z-1)* sum(z^k)[k=0..k-1] , y = z^k
+returns 1+x-y == 0
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int z, k;
+    int x, y, c;
+    z = __VERIFIER_nondet_int();
+    k = __VERIFIER_nondet_int();
+
+    x = 1;
+    y = z;
+    c = 1;
+
+    while (1) {
+        //__VERIFIER_assert(x*z - x - y + 1 == 0);
+
+        if (!(x*z - x - y + 1 + c < k)) 
+            break;
+
+        c = c + 1;
+        x = x * z + 1;
+        y = y * z;
+
+    }  //geo1
+
+    x = x * (z - 1);
+
+    //__VERIFIER_assert(1 + x - y == 0);
+    return 0;
+}

--- a/c/termination-nla/geo1-both-t.i
+++ b/c/termination-nla/geo1-both-t.i
@@ -1,0 +1,19 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int z, k;
+    int x, y, c;
+    z = __VERIFIER_nondet_int();
+    k = __VERIFIER_nondet_int();
+    x = 1;
+    y = z;
+    c = 1;
+    while (1) {
+        if (!(x*z - x - y + 1 + c < k))
+            break;
+        c = c + 1;
+        x = x * z + 1;
+        y = y * z;
+    }
+    x = x * (z - 1);
+    return 0;
+}

--- a/c/termination-nla/geo1-both-t.yml
+++ b/c/termination-nla/geo1-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'geo1-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/geo2-both-nt.c
+++ b/c/termination-nla/geo2-both-nt.c
@@ -1,0 +1,36 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* 
+Geometric Series
+computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int z, k;
+    int x, y, c;
+    z = __VERIFIER_nondet_int();
+    k = __VERIFIER_nondet_int();
+
+    x = 1;
+    y = 1;
+    c = 1;
+
+    while (1) {
+        // __VERIFIER_assert(1 + x*z - x - z*y == 0);
+
+        if (!(1 + x*z - x - z*y == 0))
+            break;
+
+        c = c + 1;
+        x = x * z + 1;
+        y = y * z;
+    }
+    // __VERIFIER_assert(1 + x*z - x - z*y == 0);
+    return 0;
+}

--- a/c/termination-nla/geo2-both-nt.i
+++ b/c/termination-nla/geo2-both-nt.i
@@ -1,0 +1,18 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int z, k;
+    int x, y, c;
+    z = __VERIFIER_nondet_int();
+    k = __VERIFIER_nondet_int();
+    x = 1;
+    y = 1;
+    c = 1;
+    while (1) {
+        if (!(1 + x*z - x - z*y == 0))
+            break;
+        c = c + 1;
+        x = x * z + 1;
+        y = y * z;
+    }
+    return 0;
+}

--- a/c/termination-nla/geo2-both-nt.yml
+++ b/c/termination-nla/geo2-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'geo2-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/geo2-both-t.c
+++ b/c/termination-nla/geo2-both-t.c
@@ -1,0 +1,36 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* 
+Geometric Series
+computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int z, k;
+    int x, y, c;
+    z = __VERIFIER_nondet_int();
+    k = __VERIFIER_nondet_int();
+
+    x = 1;
+    y = 1;
+    c = 1;
+
+    while (1) {
+        // __VERIFIER_assert(1 + x*z - x - z*y == 0);
+
+        if (!(1 + x*z - x - z*y + c < k))
+            break;
+
+        c = c + 1;
+        x = x * z + 1;
+        y = y * z;
+    }
+    // __VERIFIER_assert(1 + x*z - x - z*y == 0);
+    return 0;
+}

--- a/c/termination-nla/geo2-both-t.i
+++ b/c/termination-nla/geo2-both-t.i
@@ -1,0 +1,18 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int z, k;
+    int x, y, c;
+    z = __VERIFIER_nondet_int();
+    k = __VERIFIER_nondet_int();
+    x = 1;
+    y = 1;
+    c = 1;
+    while (1) {
+        if (!(1 + x*z - x - z*y + c < k))
+            break;
+        c = c + 1;
+        x = x * z + 1;
+        y = y * z;
+    }
+    return 0;
+}

--- a/c/termination-nla/geo2-both-t.yml
+++ b/c/termination-nla/geo2-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'geo2-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/geo3-both-nt.c
+++ b/c/termination-nla/geo3-both-nt.c
@@ -1,0 +1,37 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* 
+Geometric Series
+computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int z, a, k;
+    int x, y, c;
+    z = __VERIFIER_nondet_int();
+    a = __VERIFIER_nondet_int();
+    k = __VERIFIER_nondet_int();
+
+    x = a;
+    y = 1;
+    c = 1;
+
+    while (1) {
+        // __VERIFIER_assert(z*x - x + a - a*z*y == 0);
+
+        if (!(z*x - x + a - a*z*y == 0))
+            break;
+
+        c = c + 1;
+        x = x * z + a;
+        y = y * z;
+    }
+    // __VERIFIER_assert(z*x - x + a - a*z*y == 0);
+    return x;
+}

--- a/c/termination-nla/geo3-both-nt.i
+++ b/c/termination-nla/geo3-both-nt.i
@@ -1,0 +1,19 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int z, a, k;
+    int x, y, c;
+    z = __VERIFIER_nondet_int();
+    a = __VERIFIER_nondet_int();
+    k = __VERIFIER_nondet_int();
+    x = a;
+    y = 1;
+    c = 1;
+    while (1) {
+        if (!(z*x - x + a - a*z*y == 0))
+            break;
+        c = c + 1;
+        x = x * z + a;
+        y = y * z;
+    }
+    return x;
+}

--- a/c/termination-nla/geo3-both-nt.yml
+++ b/c/termination-nla/geo3-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'geo3-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/geo3-both-t.c
+++ b/c/termination-nla/geo3-both-t.c
@@ -1,0 +1,37 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* 
+Geometric Series
+computes x = sum(z^k)[k=0..k-1], y = z^(k-1)
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int z, a, k;
+    int x, y, c;
+    z = __VERIFIER_nondet_int();
+    a = __VERIFIER_nondet_int();
+    k = __VERIFIER_nondet_int();
+
+    x = a;
+    y = 1;
+    c = 1;
+
+    while (1) {
+        // __VERIFIER_assert(z*x - x + a - a*z*y == 0);
+
+        if (!(z*x - x + a - a*z*y + c < k))
+            break;
+
+        c = c + 1;
+        x = x * z + a;
+        y = y * z;
+    }
+    // __VERIFIER_assert(z*x - x + a - a*z*y == 0);
+    return x;
+}

--- a/c/termination-nla/geo3-both-t.i
+++ b/c/termination-nla/geo3-both-t.i
@@ -1,0 +1,19 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int z, a, k;
+    int x, y, c;
+    z = __VERIFIER_nondet_int();
+    a = __VERIFIER_nondet_int();
+    k = __VERIFIER_nondet_int();
+    x = a;
+    y = 1;
+    c = 1;
+    while (1) {
+        if (!(z*x - x + a - a*z*y + c < k))
+            break;
+        c = c + 1;
+        x = x * z + a;
+        y = y * z;
+    }
+    return x;
+}

--- a/c/termination-nla/geo3-both-t.yml
+++ b/c/termination-nla/geo3-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'geo3-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/hard-both-nt.c
+++ b/c/termination-nla/hard-both-nt.c
@@ -1,0 +1,55 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+  hardware integer division program, by Manna
+  returns q==A//B
+  */
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int A, B;
+    int r, d, p, q;
+    A = __VERIFIER_nondet_int();
+    B = __VERIFIER_nondet_int();
+    //assume_abort_if_not(B >= 1);
+    if (B < 1) return 0;
+
+    r = A;
+    d = B;
+    p = 1;
+    q = 0;
+
+    while (1) {
+        // __VERIFIER_assert(q == 0);
+        // __VERIFIER_assert(r == A);
+        // __VERIFIER_assert(d == B * p);
+        if (!(d == B * p)) break;
+
+        d = 2 * d;
+        p = 2 * p;
+    }
+
+    while (1) {
+        // __VERIFIER_assert(A == q*B + r);
+        // __VERIFIER_assert(d == B*p);
+
+        if (!(A == q*B + r)) break;
+
+        d = d / 2;
+        p = p / 2;
+        if (r >= d) {
+            r = r - d;
+            q = q + p;
+        }
+    }
+
+    // __VERIFIER_assert(A == d*q + r);
+    // __VERIFIER_assert(B == d);    
+    return 0;
+}

--- a/c/termination-nla/hard-both-nt.i
+++ b/c/termination-nla/hard-both-nt.i
@@ -1,0 +1,27 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int A, B;
+    int r, d, p, q;
+    A = __VERIFIER_nondet_int();
+    B = __VERIFIER_nondet_int();
+    if (B < 1) return 0;
+    r = A;
+    d = B;
+    p = 1;
+    q = 0;
+    while (1) {
+        if (!(d == B * p)) break;
+        d = 2 * d;
+        p = 2 * p;
+    }
+    while (1) {
+        if (!(A == q*B + r)) break;
+        d = d / 2;
+        p = p / 2;
+        if (r >= d) {
+            r = r - d;
+            q = q + p;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/hard-both-nt.yml
+++ b/c/termination-nla/hard-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'hard-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/hard-both-t.c
+++ b/c/termination-nla/hard-both-t.c
@@ -1,0 +1,55 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+  hardware integer division program, by Manna
+  returns q==A//B
+  */
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int A, B;
+    int r, d, p, q;
+    A = __VERIFIER_nondet_int();
+    B = __VERIFIER_nondet_int();
+    //assume_abort_if_not(B >= 1);
+    if (B < 1) return 0;
+
+    r = A;
+    d = B;
+    p = 1;
+    q = 0;
+
+    while (1) {
+        // __VERIFIER_assert(q == 0);
+        // __VERIFIER_assert(r == A);
+        // __VERIFIER_assert(d == B * p);
+        if (!(r >= B * p)) break;
+
+        d = 2 * d;
+        p = 2 * p;
+    }
+
+    while (1) {
+        // __VERIFIER_assert(A == q*B + r);
+        // __VERIFIER_assert(d == B*p);
+
+        if (!(A - q*B - r + p != 1)) break;
+
+        d = d / 2;
+        p = p / 2;
+        if (r >= d) {
+            r = r - d;
+            q = q + p;
+        }
+    }
+
+    // __VERIFIER_assert(A == d*q + r);
+    // __VERIFIER_assert(B == d);    
+    return 0;
+}

--- a/c/termination-nla/hard-both-t.i
+++ b/c/termination-nla/hard-both-t.i
@@ -1,0 +1,27 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int A, B;
+    int r, d, p, q;
+    A = __VERIFIER_nondet_int();
+    B = __VERIFIER_nondet_int();
+    if (B < 1) return 0;
+    r = A;
+    d = B;
+    p = 1;
+    q = 0;
+    while (1) {
+        if (!(r >= B * p)) break;
+        d = 2 * d;
+        p = 2 * p;
+    }
+    while (1) {
+        if (!(A - q*B - r + p != 1)) break;
+        d = d / 2;
+        p = p / 2;
+        if (r >= d) {
+            r = r - d;
+            q = q + p;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/hard-both-t.yml
+++ b/c/termination-nla/hard-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'hard-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/hard2-both-nt.c
+++ b/c/termination-nla/hard2-both-nt.c
@@ -1,0 +1,53 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+  hardware integer division program, by Manna
+  returns q==A//B
+  */
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int A, B;
+    int r, d, p, q;
+    A = __VERIFIER_nondet_int();
+    B = 1;
+
+    r = A;
+    d = B;
+    p = 1;
+    q = 0;
+
+    while (1) {
+        // __VERIFIER_assert(q == 0);
+        // __VERIFIER_assert(r == A);
+        // __VERIFIER_assert(d == B * p);
+        if (!(d == B * p)) break;
+
+        d = 2 * d;
+        p = 2 * p;
+    }
+
+    while (1) {
+        // __VERIFIER_assert(A == q*B + r);
+        // __VERIFIER_assert(d == B*p);
+
+        if (!(A == q*B + r)) break;
+
+        d = d / 2;
+        p = p / 2;
+        if (r >= d) {
+            r = r - d;
+            q = q + p;
+        }
+    }
+
+    // __VERIFIER_assert(A == d*q + r);
+    // __VERIFIER_assert(B == d);    
+    return 0;
+}

--- a/c/termination-nla/hard2-both-nt.i
+++ b/c/termination-nla/hard2-both-nt.i
@@ -1,0 +1,26 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int A, B;
+    int r, d, p, q;
+    A = __VERIFIER_nondet_int();
+    B = 1;
+    r = A;
+    d = B;
+    p = 1;
+    q = 0;
+    while (1) {
+        if (!(d == B * p)) break;
+        d = 2 * d;
+        p = 2 * p;
+    }
+    while (1) {
+        if (!(A == q*B + r)) break;
+        d = d / 2;
+        p = p / 2;
+        if (r >= d) {
+            r = r - d;
+            q = q + p;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/hard2-both-nt.yml
+++ b/c/termination-nla/hard2-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'hard2-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/hard2-both-t.c
+++ b/c/termination-nla/hard2-both-t.c
@@ -1,0 +1,53 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+  hardware integer division program, by Manna
+  returns q==A//B
+  */
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int A, B;
+    int r, d, p, q;
+    A = __VERIFIER_nondet_int();
+    B = 1;
+
+    r = A;
+    d = B;
+    p = 1;
+    q = 0;
+
+    while (1) {
+        // __VERIFIER_assert(q == 0);
+        // __VERIFIER_assert(r == A);
+        // __VERIFIER_assert(d == B * p);
+        if (!(B * p - d + r >= d)) break;
+
+        d = 2 * d;
+        p = 2 * p;
+    }
+
+    while (1) {
+        // __VERIFIER_assert(A == q*B + r);
+        // __VERIFIER_assert(d == B*p);
+
+        if (!(q*B + r - A + p != 1)) break;
+
+        d = d / 2;
+        p = p / 2;
+        if (r >= d) {
+            r = r - d;
+            q = q + p;
+        }
+    }
+
+    // __VERIFIER_assert(A == d*q + r);
+    // __VERIFIER_assert(B == d);    
+    return 0;
+}

--- a/c/termination-nla/hard2-both-t.i
+++ b/c/termination-nla/hard2-both-t.i
@@ -1,0 +1,26 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int A, B;
+    int r, d, p, q;
+    A = __VERIFIER_nondet_int();
+    B = 1;
+    r = A;
+    d = B;
+    p = 1;
+    q = 0;
+    while (1) {
+        if (!(B * p - d + r >= d)) break;
+        d = 2 * d;
+        p = 2 * p;
+    }
+    while (1) {
+        if (!(q*B + r - A + p != 1)) break;
+        d = d / 2;
+        p = p / 2;
+        if (r >= d) {
+            r = r - d;
+            q = q + p;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/hard2-both-t.yml
+++ b/c/termination-nla/hard2-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'hard2-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/knuth-both-nt.c
+++ b/c/termination-nla/knuth-both-nt.c
@@ -1,0 +1,71 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* algorithm searching for a divisor for factorization, by Knuth */
+
+#include <limits.h>
+
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+
+extern double sqrt(double);
+
+int main() {
+    unsigned n, a;
+    unsigned r, k, q, d, s, t;
+    n = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_unsigned_int();
+    // assume_abort_if_not(n < UINT_MAX/8);
+    // assume_abort_if_not(a > 2);
+
+    if (n >= UINT_MAX/8 || a <= 2) {
+        return 0;
+    }
+
+    d = a;
+    r = n % d;
+    t = 0;
+    k = n % (d - 2);
+    q = 4 * (n / (d - 2) - n / d);
+    s = sqrt(n);
+
+    while (1) {
+        // __VERIFIER_assert(d * d * q - 2 * q * d - 4 * r * d + 4 * k * d + 8 * r == 8 * n);
+        // __VERIFIER_assert(k * t == t * t);
+        // __VERIFIER_assert(d * d * q - 2 * d * q - 4 * d * r + 4 * d * t + 4 * a * k - 4 * a * t - 8 * n + 8 * r == 0);
+        // __VERIFIER_assert(d * k - d * t - a * k + a * t == 0);
+
+        if (!(d * k - d * t - a * k + a * t == 0)) break;
+
+        if (2 * r  + q < k) {
+            t = r;
+            r = 2 * r - k + q + d + 2;
+            k = t;
+            q = q + 4;
+            d = d + 2;
+        } else if ((2 * r  + q >= k) && (2 * r + q < d + k + 2)) {
+            t = r;
+            r = 2 * r - k + q;
+            k = t;
+            d = d + 2;
+        } else if ((2 * r  + q >= k) && (2 * r + q >= d + k + 2) && (2 * r + q < 2 * d + k + 4)) {
+            t = r;
+            r = 2 * r - k + q - d - 2;
+            k = t;
+            q = q - 4;
+            d = d + 2;
+        } else { /* ((2*r-k+q>=0)&&(2*r-k+q>=2*d+4)) */
+            t = r;
+            r = 2 * r - k + q - 2 * d - 4;
+            k = t;
+            q = q - 8;
+            d = d + 2;
+        }
+    }
+
+    //postconds ? cannot be obtained with DIG (Syminfer)
+    return 0;
+}

--- a/c/termination-nla/knuth-both-nt.i
+++ b/c/termination-nla/knuth-both-nt.i
@@ -1,0 +1,45 @@
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern double sqrt(double);
+int main() {
+    unsigned n, a;
+    unsigned r, k, q, d, s, t;
+    n = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_unsigned_int();
+    if (n >= (0x7fffffff * 2U + 1U)/8 || a <= 2) {
+        return 0;
+    }
+    d = a;
+    r = n % d;
+    t = 0;
+    k = n % (d - 2);
+    q = 4 * (n / (d - 2) - n / d);
+    s = sqrt(n);
+    while (1) {
+        if (!(d * k - d * t - a * k + a * t == 0)) break;
+        if (2 * r + q < k) {
+            t = r;
+            r = 2 * r - k + q + d + 2;
+            k = t;
+            q = q + 4;
+            d = d + 2;
+        } else if ((2 * r + q >= k) && (2 * r + q < d + k + 2)) {
+            t = r;
+            r = 2 * r - k + q;
+            k = t;
+            d = d + 2;
+        } else if ((2 * r + q >= k) && (2 * r + q >= d + k + 2) && (2 * r + q < 2 * d + k + 4)) {
+            t = r;
+            r = 2 * r - k + q - d - 2;
+            k = t;
+            q = q - 4;
+            d = d + 2;
+        } else {
+            t = r;
+            r = 2 * r - k + q - 2 * d - 4;
+            k = t;
+            q = q - 8;
+            d = d + 2;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/knuth-both-nt.yml
+++ b/c/termination-nla/knuth-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'knuth-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/knuth-both-t.c
+++ b/c/termination-nla/knuth-both-t.c
@@ -1,0 +1,71 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* algorithm searching for a divisor for factorization, by Knuth */
+
+#include <limits.h>
+#include <math.h>
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+
+extern double sqrt(double);
+
+int main() {
+    unsigned n, a;
+    unsigned r, k, q, d, s, t;
+    n = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_unsigned_int();
+    // assume_abort_if_not(n < UINT_MAX/8);
+    // assume_abort_if_not(a > 2);
+
+    if (n >= UINT_MAX/8 || a <= 2) {
+        return 0;
+    }
+
+    d = a;
+    r = n % d;
+    t = 0;
+    k = n % (d - 2);
+    q = 4 * (n / (d - 2) - n / d);
+    s = sqrt(n);
+
+    while (1) {
+        // __VERIFIER_assert(d * d * q - 2 * q * d - 4 * r * d + 4 * k * d + 8 * r == 8 * n);
+        // __VERIFIER_assert(k * t == t * t);
+        // __VERIFIER_assert(d * d * q - 2 * d * q - 4 * d * r + 4 * d * t + 4 * a * k - 4 * a * t - 8 * n + 8 * r == 0);
+        // __VERIFIER_assert(d * k - d * t - a * k + a * t == 0);
+
+        if (!((s + d * k - d * t - a * k + a * t >= d) && (r != 0))) break;
+
+        if (2 * r  + q < k) {
+            t = r;
+            r = 2 * r - k + q + d + 2;
+            k = t;
+            q = q + 4;
+            d = d + 2;
+        } else if ((2 * r  + q >= k) && (2 * r + q < d + k + 2)) {
+            t = r;
+            r = 2 * r - k + q;
+            k = t;
+            d = d + 2;
+        } else if ((2 * r  + q >= k) && (2 * r + q >= d + k + 2) && (2 * r + q < 2 * d + k + 4)) {
+            t = r;
+            r = 2 * r - k + q - d - 2;
+            k = t;
+            q = q - 4;
+            d = d + 2;
+        } else { /* ((2*r-k+q>=0)&&(2*r-k+q>=2*d+4)) */
+            t = r;
+            r = 2 * r - k + q - 2 * d - 4;
+            k = t;
+            q = q - 8;
+            d = d + 2;
+        }
+    }
+
+    //postconds ? cannot be obtained with DIG (Syminfer)
+    return 0;
+}

--- a/c/termination-nla/knuth-both-t.i
+++ b/c/termination-nla/knuth-both-t.i
@@ -1,0 +1,385 @@
+
+typedef unsigned char __u_char;
+typedef unsigned short int __u_short;
+typedef unsigned int __u_int;
+typedef unsigned long int __u_long;
+typedef signed char __int8_t;
+typedef unsigned char __uint8_t;
+typedef signed short int __int16_t;
+typedef unsigned short int __uint16_t;
+typedef signed int __int32_t;
+typedef unsigned int __uint32_t;
+__extension__ typedef signed long long int __int64_t;
+__extension__ typedef unsigned long long int __uint64_t;
+typedef __int8_t __int_least8_t;
+typedef __uint8_t __uint_least8_t;
+typedef __int16_t __int_least16_t;
+typedef __uint16_t __uint_least16_t;
+typedef __int32_t __int_least32_t;
+typedef __uint32_t __uint_least32_t;
+typedef __int64_t __int_least64_t;
+typedef __uint64_t __uint_least64_t;
+__extension__ typedef long long int __quad_t;
+__extension__ typedef unsigned long long int __u_quad_t;
+__extension__ typedef long long int __intmax_t;
+__extension__ typedef unsigned long long int __uintmax_t;
+__extension__ typedef __uint64_t __dev_t;
+__extension__ typedef unsigned int __uid_t;
+__extension__ typedef unsigned int __gid_t;
+__extension__ typedef unsigned long int __ino_t;
+__extension__ typedef __uint64_t __ino64_t;
+__extension__ typedef unsigned int __mode_t;
+__extension__ typedef unsigned int __nlink_t;
+__extension__ typedef long int __off_t;
+__extension__ typedef __int64_t __off64_t;
+__extension__ typedef int __pid_t;
+__extension__ typedef struct { int __val[2]; } __fsid_t;
+__extension__ typedef long int __clock_t;
+__extension__ typedef unsigned long int __rlim_t;
+__extension__ typedef __uint64_t __rlim64_t;
+__extension__ typedef unsigned int __id_t;
+__extension__ typedef long int __time_t;
+__extension__ typedef unsigned int __useconds_t;
+__extension__ typedef long int __suseconds_t;
+__extension__ typedef int __daddr_t;
+__extension__ typedef int __key_t;
+__extension__ typedef int __clockid_t;
+__extension__ typedef void * __timer_t;
+__extension__ typedef long int __blksize_t;
+__extension__ typedef long int __blkcnt_t;
+__extension__ typedef __int64_t __blkcnt64_t;
+__extension__ typedef unsigned long int __fsblkcnt_t;
+__extension__ typedef __uint64_t __fsblkcnt64_t;
+__extension__ typedef unsigned long int __fsfilcnt_t;
+__extension__ typedef __uint64_t __fsfilcnt64_t;
+__extension__ typedef int __fsword_t;
+__extension__ typedef int __ssize_t;
+__extension__ typedef long int __syscall_slong_t;
+__extension__ typedef unsigned long int __syscall_ulong_t;
+typedef __off64_t __loff_t;
+typedef char *__caddr_t;
+__extension__ typedef int __intptr_t;
+__extension__ typedef unsigned int __socklen_t;
+typedef int __sig_atomic_t;
+__extension__ typedef __int64_t __time64_t;
+typedef long double float_t;
+typedef long double double_t;
+extern int __fpclassify (double __value) __attribute__ ((__nothrow__ , __leaf__))
+     __attribute__ ((__const__));
+extern int __signbit (double __value) __attribute__ ((__nothrow__ , __leaf__))
+     __attribute__ ((__const__));
+extern int __isinf (double __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int __finite (double __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int __isnan (double __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int __iseqsig (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern int __issignaling (double __value) __attribute__ ((__nothrow__ , __leaf__))
+     __attribute__ ((__const__));
+extern double acos (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __acos (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double asin (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __asin (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double atan (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __atan (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double atan2 (double __y, double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __atan2 (double __y, double __x) __attribute__ ((__nothrow__ , __leaf__));
+ extern double cos (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __cos (double __x) __attribute__ ((__nothrow__ , __leaf__));
+ extern double sin (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __sin (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double tan (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __tan (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double cosh (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __cosh (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double sinh (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __sinh (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double tanh (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __tanh (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double acosh (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __acosh (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double asinh (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __asinh (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double atanh (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __atanh (double __x) __attribute__ ((__nothrow__ , __leaf__));
+ extern double exp (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __exp (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double frexp (double __x, int *__exponent) __attribute__ ((__nothrow__ , __leaf__)); extern double __frexp (double __x, int *__exponent) __attribute__ ((__nothrow__ , __leaf__));
+extern double ldexp (double __x, int __exponent) __attribute__ ((__nothrow__ , __leaf__)); extern double __ldexp (double __x, int __exponent) __attribute__ ((__nothrow__ , __leaf__));
+ extern double log (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __log (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double log10 (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __log10 (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double modf (double __x, double *__iptr) __attribute__ ((__nothrow__ , __leaf__)); extern double __modf (double __x, double *__iptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern double expm1 (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __expm1 (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double log1p (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __log1p (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double logb (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __logb (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double exp2 (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __exp2 (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double log2 (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __log2 (double __x) __attribute__ ((__nothrow__ , __leaf__));
+ extern double pow (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__)); extern double __pow (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern double sqrt (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __sqrt (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double hypot (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__)); extern double __hypot (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern double cbrt (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __cbrt (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double ceil (double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern double __ceil (double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern double fabs (double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern double __fabs (double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern double floor (double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern double __floor (double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern double fmod (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__)); extern double __fmod (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern int isinf (double __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int finite (double __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern double drem (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__)); extern double __drem (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern double significand (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __significand (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double copysign (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern double __copysign (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern double nan (const char *__tagb) __attribute__ ((__nothrow__ , __leaf__)); extern double __nan (const char *__tagb) __attribute__ ((__nothrow__ , __leaf__));
+extern int isnan (double __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern double j0 (double) __attribute__ ((__nothrow__ , __leaf__)); extern double __j0 (double) __attribute__ ((__nothrow__ , __leaf__));
+extern double j1 (double) __attribute__ ((__nothrow__ , __leaf__)); extern double __j1 (double) __attribute__ ((__nothrow__ , __leaf__));
+extern double jn (int, double) __attribute__ ((__nothrow__ , __leaf__)); extern double __jn (int, double) __attribute__ ((__nothrow__ , __leaf__));
+extern double y0 (double) __attribute__ ((__nothrow__ , __leaf__)); extern double __y0 (double) __attribute__ ((__nothrow__ , __leaf__));
+extern double y1 (double) __attribute__ ((__nothrow__ , __leaf__)); extern double __y1 (double) __attribute__ ((__nothrow__ , __leaf__));
+extern double yn (int, double) __attribute__ ((__nothrow__ , __leaf__)); extern double __yn (int, double) __attribute__ ((__nothrow__ , __leaf__));
+extern double erf (double) __attribute__ ((__nothrow__ , __leaf__)); extern double __erf (double) __attribute__ ((__nothrow__ , __leaf__));
+extern double erfc (double) __attribute__ ((__nothrow__ , __leaf__)); extern double __erfc (double) __attribute__ ((__nothrow__ , __leaf__));
+extern double lgamma (double) __attribute__ ((__nothrow__ , __leaf__)); extern double __lgamma (double) __attribute__ ((__nothrow__ , __leaf__));
+extern double tgamma (double) __attribute__ ((__nothrow__ , __leaf__)); extern double __tgamma (double) __attribute__ ((__nothrow__ , __leaf__));
+extern double gamma (double) __attribute__ ((__nothrow__ , __leaf__)); extern double __gamma (double) __attribute__ ((__nothrow__ , __leaf__));
+extern double lgamma_r (double, int *__signgamp) __attribute__ ((__nothrow__ , __leaf__)); extern double __lgamma_r (double, int *__signgamp) __attribute__ ((__nothrow__ , __leaf__));
+extern double rint (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __rint (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double nextafter (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__)); extern double __nextafter (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern double nexttoward (double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)); extern double __nexttoward (double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern double remainder (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__)); extern double __remainder (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern double scalbn (double __x, int __n) __attribute__ ((__nothrow__ , __leaf__)); extern double __scalbn (double __x, int __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int ilogb (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern int __ilogb (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double scalbln (double __x, long int __n) __attribute__ ((__nothrow__ , __leaf__)); extern double __scalbln (double __x, long int __n) __attribute__ ((__nothrow__ , __leaf__));
+extern double nearbyint (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern double __nearbyint (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double round (double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern double __round (double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern double trunc (double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern double __trunc (double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern double remquo (double __x, double __y, int *__quo) __attribute__ ((__nothrow__ , __leaf__)); extern double __remquo (double __x, double __y, int *__quo) __attribute__ ((__nothrow__ , __leaf__));
+extern long int lrint (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long int __lrint (double __x) __attribute__ ((__nothrow__ , __leaf__));
+__extension__
+extern long long int llrint (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long long int __llrint (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long int lround (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long int __lround (double __x) __attribute__ ((__nothrow__ , __leaf__));
+__extension__
+extern long long int llround (double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long long int __llround (double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern double fdim (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__)); extern double __fdim (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern double fmax (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern double __fmax (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern double fmin (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern double __fmin (double __x, double __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern double fma (double __x, double __y, double __z) __attribute__ ((__nothrow__ , __leaf__)); extern double __fma (double __x, double __y, double __z) __attribute__ ((__nothrow__ , __leaf__));
+extern double scalb (double __x, double __n) __attribute__ ((__nothrow__ , __leaf__)); extern double __scalb (double __x, double __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int __fpclassifyf (float __value) __attribute__ ((__nothrow__ , __leaf__))
+     __attribute__ ((__const__));
+extern int __signbitf (float __value) __attribute__ ((__nothrow__ , __leaf__))
+     __attribute__ ((__const__));
+extern int __isinff (float __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int __finitef (float __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int __isnanf (float __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int __iseqsigf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__));
+extern int __issignalingf (float __value) __attribute__ ((__nothrow__ , __leaf__))
+     __attribute__ ((__const__));
+extern float acosf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __acosf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float asinf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __asinf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float atanf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __atanf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float atan2f (float __y, float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __atan2f (float __y, float __x) __attribute__ ((__nothrow__ , __leaf__));
+ extern float cosf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __cosf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+ extern float sinf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __sinf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float tanf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __tanf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float coshf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __coshf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float sinhf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __sinhf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float tanhf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __tanhf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float acoshf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __acoshf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float asinhf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __asinhf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float atanhf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __atanhf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+ extern float expf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __expf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float frexpf (float __x, int *__exponent) __attribute__ ((__nothrow__ , __leaf__)); extern float __frexpf (float __x, int *__exponent) __attribute__ ((__nothrow__ , __leaf__));
+extern float ldexpf (float __x, int __exponent) __attribute__ ((__nothrow__ , __leaf__)); extern float __ldexpf (float __x, int __exponent) __attribute__ ((__nothrow__ , __leaf__));
+ extern float logf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __logf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float log10f (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __log10f (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float modff (float __x, float *__iptr) __attribute__ ((__nothrow__ , __leaf__)); extern float __modff (float __x, float *__iptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern float expm1f (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __expm1f (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float log1pf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __log1pf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float logbf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __logbf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float exp2f (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __exp2f (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float log2f (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __log2f (float __x) __attribute__ ((__nothrow__ , __leaf__));
+ extern float powf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__)); extern float __powf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__));
+extern float sqrtf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __sqrtf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float hypotf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__)); extern float __hypotf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__));
+extern float cbrtf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __cbrtf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float ceilf (float __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern float __ceilf (float __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern float fabsf (float __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern float __fabsf (float __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern float floorf (float __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern float __floorf (float __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern float fmodf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__)); extern float __fmodf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__));
+extern int isinff (float __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int finitef (float __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern float dremf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__)); extern float __dremf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__));
+extern float significandf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __significandf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float copysignf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern float __copysignf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern float nanf (const char *__tagb) __attribute__ ((__nothrow__ , __leaf__)); extern float __nanf (const char *__tagb) __attribute__ ((__nothrow__ , __leaf__));
+extern int isnanf (float __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern float j0f (float) __attribute__ ((__nothrow__ , __leaf__)); extern float __j0f (float) __attribute__ ((__nothrow__ , __leaf__));
+extern float j1f (float) __attribute__ ((__nothrow__ , __leaf__)); extern float __j1f (float) __attribute__ ((__nothrow__ , __leaf__));
+extern float jnf (int, float) __attribute__ ((__nothrow__ , __leaf__)); extern float __jnf (int, float) __attribute__ ((__nothrow__ , __leaf__));
+extern float y0f (float) __attribute__ ((__nothrow__ , __leaf__)); extern float __y0f (float) __attribute__ ((__nothrow__ , __leaf__));
+extern float y1f (float) __attribute__ ((__nothrow__ , __leaf__)); extern float __y1f (float) __attribute__ ((__nothrow__ , __leaf__));
+extern float ynf (int, float) __attribute__ ((__nothrow__ , __leaf__)); extern float __ynf (int, float) __attribute__ ((__nothrow__ , __leaf__));
+extern float erff (float) __attribute__ ((__nothrow__ , __leaf__)); extern float __erff (float) __attribute__ ((__nothrow__ , __leaf__));
+extern float erfcf (float) __attribute__ ((__nothrow__ , __leaf__)); extern float __erfcf (float) __attribute__ ((__nothrow__ , __leaf__));
+extern float lgammaf (float) __attribute__ ((__nothrow__ , __leaf__)); extern float __lgammaf (float) __attribute__ ((__nothrow__ , __leaf__));
+extern float tgammaf (float) __attribute__ ((__nothrow__ , __leaf__)); extern float __tgammaf (float) __attribute__ ((__nothrow__ , __leaf__));
+extern float gammaf (float) __attribute__ ((__nothrow__ , __leaf__)); extern float __gammaf (float) __attribute__ ((__nothrow__ , __leaf__));
+extern float lgammaf_r (float, int *__signgamp) __attribute__ ((__nothrow__ , __leaf__)); extern float __lgammaf_r (float, int *__signgamp) __attribute__ ((__nothrow__ , __leaf__));
+extern float rintf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __rintf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float nextafterf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__)); extern float __nextafterf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__));
+extern float nexttowardf (float __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)); extern float __nexttowardf (float __x, long double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern float remainderf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__)); extern float __remainderf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__));
+extern float scalbnf (float __x, int __n) __attribute__ ((__nothrow__ , __leaf__)); extern float __scalbnf (float __x, int __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int ilogbf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern int __ilogbf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float scalblnf (float __x, long int __n) __attribute__ ((__nothrow__ , __leaf__)); extern float __scalblnf (float __x, long int __n) __attribute__ ((__nothrow__ , __leaf__));
+extern float nearbyintf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern float __nearbyintf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float roundf (float __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern float __roundf (float __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern float truncf (float __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern float __truncf (float __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern float remquof (float __x, float __y, int *__quo) __attribute__ ((__nothrow__ , __leaf__)); extern float __remquof (float __x, float __y, int *__quo) __attribute__ ((__nothrow__ , __leaf__));
+extern long int lrintf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern long int __lrintf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+__extension__
+extern long long int llrintf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern long long int __llrintf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long int lroundf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern long int __lroundf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+__extension__
+extern long long int llroundf (float __x) __attribute__ ((__nothrow__ , __leaf__)); extern long long int __llroundf (float __x) __attribute__ ((__nothrow__ , __leaf__));
+extern float fdimf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__)); extern float __fdimf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__));
+extern float fmaxf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern float __fmaxf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern float fminf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern float __fminf (float __x, float __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern float fmaf (float __x, float __y, float __z) __attribute__ ((__nothrow__ , __leaf__)); extern float __fmaf (float __x, float __y, float __z) __attribute__ ((__nothrow__ , __leaf__));
+extern float scalbf (float __x, float __n) __attribute__ ((__nothrow__ , __leaf__)); extern float __scalbf (float __x, float __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int __fpclassifyl (long double __value) __attribute__ ((__nothrow__ , __leaf__))
+     __attribute__ ((__const__));
+extern int __signbitl (long double __value) __attribute__ ((__nothrow__ , __leaf__))
+     __attribute__ ((__const__));
+extern int __isinfl (long double __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int __finitel (long double __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int __isnanl (long double __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int __iseqsigl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern int __issignalingl (long double __value) __attribute__ ((__nothrow__ , __leaf__))
+     __attribute__ ((__const__));
+extern long double acosl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __acosl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double asinl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __asinl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double atanl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __atanl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double atan2l (long double __y, long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __atan2l (long double __y, long double __x) __attribute__ ((__nothrow__ , __leaf__));
+ extern long double cosl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __cosl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+ extern long double sinl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __sinl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double tanl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __tanl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double coshl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __coshl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double sinhl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __sinhl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double tanhl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __tanhl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double acoshl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __acoshl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double asinhl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __asinhl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double atanhl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __atanhl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+ extern long double expl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __expl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double frexpl (long double __x, int *__exponent) __attribute__ ((__nothrow__ , __leaf__)); extern long double __frexpl (long double __x, int *__exponent) __attribute__ ((__nothrow__ , __leaf__));
+extern long double ldexpl (long double __x, int __exponent) __attribute__ ((__nothrow__ , __leaf__)); extern long double __ldexpl (long double __x, int __exponent) __attribute__ ((__nothrow__ , __leaf__));
+ extern long double logl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __logl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double log10l (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __log10l (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double modfl (long double __x, long double *__iptr) __attribute__ ((__nothrow__ , __leaf__)); extern long double __modfl (long double __x, long double *__iptr) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (2)));
+extern long double expm1l (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __expm1l (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double log1pl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __log1pl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double logbl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __logbl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double exp2l (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __exp2l (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double log2l (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __log2l (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+ extern long double powl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)); extern long double __powl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern long double sqrtl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __sqrtl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double hypotl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)); extern long double __hypotl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern long double cbrtl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __cbrtl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double ceill (long double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern long double __ceill (long double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern long double fabsl (long double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern long double __fabsl (long double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern long double floorl (long double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern long double __floorl (long double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern long double fmodl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)); extern long double __fmodl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern int isinfl (long double __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int finitel (long double __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern long double dreml (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)); extern long double __dreml (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern long double significandl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __significandl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double copysignl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern long double __copysignl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern long double nanl (const char *__tagb) __attribute__ ((__nothrow__ , __leaf__)); extern long double __nanl (const char *__tagb) __attribute__ ((__nothrow__ , __leaf__));
+extern int isnanl (long double __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern long double j0l (long double) __attribute__ ((__nothrow__ , __leaf__)); extern long double __j0l (long double) __attribute__ ((__nothrow__ , __leaf__));
+extern long double j1l (long double) __attribute__ ((__nothrow__ , __leaf__)); extern long double __j1l (long double) __attribute__ ((__nothrow__ , __leaf__));
+extern long double jnl (int, long double) __attribute__ ((__nothrow__ , __leaf__)); extern long double __jnl (int, long double) __attribute__ ((__nothrow__ , __leaf__));
+extern long double y0l (long double) __attribute__ ((__nothrow__ , __leaf__)); extern long double __y0l (long double) __attribute__ ((__nothrow__ , __leaf__));
+extern long double y1l (long double) __attribute__ ((__nothrow__ , __leaf__)); extern long double __y1l (long double) __attribute__ ((__nothrow__ , __leaf__));
+extern long double ynl (int, long double) __attribute__ ((__nothrow__ , __leaf__)); extern long double __ynl (int, long double) __attribute__ ((__nothrow__ , __leaf__));
+extern long double erfl (long double) __attribute__ ((__nothrow__ , __leaf__)); extern long double __erfl (long double) __attribute__ ((__nothrow__ , __leaf__));
+extern long double erfcl (long double) __attribute__ ((__nothrow__ , __leaf__)); extern long double __erfcl (long double) __attribute__ ((__nothrow__ , __leaf__));
+extern long double lgammal (long double) __attribute__ ((__nothrow__ , __leaf__)); extern long double __lgammal (long double) __attribute__ ((__nothrow__ , __leaf__));
+extern long double tgammal (long double) __attribute__ ((__nothrow__ , __leaf__)); extern long double __tgammal (long double) __attribute__ ((__nothrow__ , __leaf__));
+extern long double gammal (long double) __attribute__ ((__nothrow__ , __leaf__)); extern long double __gammal (long double) __attribute__ ((__nothrow__ , __leaf__));
+extern long double lgammal_r (long double, int *__signgamp) __attribute__ ((__nothrow__ , __leaf__)); extern long double __lgammal_r (long double, int *__signgamp) __attribute__ ((__nothrow__ , __leaf__));
+extern long double rintl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __rintl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double nextafterl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)); extern long double __nextafterl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern long double nexttowardl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)); extern long double __nexttowardl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern long double remainderl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)); extern long double __remainderl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern long double scalbnl (long double __x, int __n) __attribute__ ((__nothrow__ , __leaf__)); extern long double __scalbnl (long double __x, int __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int ilogbl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern int __ilogbl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double scalblnl (long double __x, long int __n) __attribute__ ((__nothrow__ , __leaf__)); extern long double __scalblnl (long double __x, long int __n) __attribute__ ((__nothrow__ , __leaf__));
+extern long double nearbyintl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long double __nearbyintl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double roundl (long double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern long double __roundl (long double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern long double truncl (long double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern long double __truncl (long double __x) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern long double remquol (long double __x, long double __y, int *__quo) __attribute__ ((__nothrow__ , __leaf__)); extern long double __remquol (long double __x, long double __y, int *__quo) __attribute__ ((__nothrow__ , __leaf__));
+extern long int lrintl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long int __lrintl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+__extension__
+extern long long int llrintl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long long int __llrintl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long int lroundl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long int __lroundl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+__extension__
+extern long long int llroundl (long double __x) __attribute__ ((__nothrow__ , __leaf__)); extern long long int __llroundl (long double __x) __attribute__ ((__nothrow__ , __leaf__));
+extern long double fdiml (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)); extern long double __fdiml (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__));
+extern long double fmaxl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern long double __fmaxl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern long double fminl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__)); extern long double __fminl (long double __x, long double __y) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern long double fmal (long double __x, long double __y, long double __z) __attribute__ ((__nothrow__ , __leaf__)); extern long double __fmal (long double __x, long double __y, long double __z) __attribute__ ((__nothrow__ , __leaf__));
+extern long double scalbl (long double __x, long double __n) __attribute__ ((__nothrow__ , __leaf__)); extern long double __scalbl (long double __x, long double __n) __attribute__ ((__nothrow__ , __leaf__));
+extern int __fpclassifyf128 (_Float128 __value) __attribute__ ((__nothrow__ , __leaf__))
+     __attribute__ ((__const__));
+extern int __signbitf128 (_Float128 __value) __attribute__ ((__nothrow__ , __leaf__))
+     __attribute__ ((__const__));
+extern int __isinff128 (_Float128 __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int __finitef128 (_Float128 __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int __isnanf128 (_Float128 __value) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__const__));
+extern int __iseqsigf128 (_Float128 __x, _Float128 __y) __attribute__ ((__nothrow__ , __leaf__));
+extern int __issignalingf128 (_Float128 __value) __attribute__ ((__nothrow__ , __leaf__))
+     __attribute__ ((__const__));
+extern int signgam;
+enum
+  {
+    FP_NAN =
+      0,
+    FP_INFINITE =
+      1,
+    FP_ZERO =
+      2,
+    FP_SUBNORMAL =
+      3,
+    FP_NORMAL =
+      4
+  };
+
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern double sqrt(double);
+int main() {
+    unsigned n, a;
+    unsigned r, k, q, d, s, t;
+    n = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_unsigned_int();
+    if (n >= (0x7fffffff * 2U + 1U)/8 || a <= 2) {
+        return 0;
+    }
+    d = a;
+    r = n % d;
+    t = 0;
+    k = n % (d - 2);
+    q = 4 * (n / (d - 2) - n / d);
+    s = sqrt(n);
+    while (1) {
+        if (!((s + d * k - d * t - a * k + a * t >= d) && (r != 0))) break;
+        if (2 * r + q < k) {
+            t = r;
+            r = 2 * r - k + q + d + 2;
+            k = t;
+            q = q + 4;
+            d = d + 2;
+        } else if ((2 * r + q >= k) && (2 * r + q < d + k + 2)) {
+            t = r;
+            r = 2 * r - k + q;
+            k = t;
+            d = d + 2;
+        } else if ((2 * r + q >= k) && (2 * r + q >= d + k + 2) && (2 * r + q < 2 * d + k + 4)) {
+            t = r;
+            r = 2 * r - k + q - d - 2;
+            k = t;
+            q = q - 4;
+            d = d + 2;
+        } else {
+            t = r;
+            r = 2 * r - k + q - 2 * d - 4;
+            k = t;
+            q = q - 8;
+            d = d + 2;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/knuth-both-t.yml
+++ b/c/termination-nla/knuth-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'knuth-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/knuth-nosqrt-both-nt.c
+++ b/c/termination-nla/knuth-nosqrt-both-nt.c
@@ -1,0 +1,74 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* algorithm searching for a divisor for factorization, by Knuth */
+
+#include <limits.h>
+
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+
+extern double sqrt(double);
+
+int main() {
+    unsigned s, a;
+    unsigned r, k, q, d, n, t;
+    s = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_unsigned_int();
+    // assume_abort_if_not(s < 8192);
+    // assume_abort_if_not(a > 2);
+
+    if (s >= 8192) {
+        return 0;
+    }
+    if (a <= 2) {
+        return 0;
+    }
+
+    n = s*s;
+    d = a;
+    r = n % d;
+    t = 0;
+    k = n % (d - 2);
+    q = 4 * (n / (d - 2) - n / d);
+
+    while (1) {
+        // __VERIFIER_assert(d * d * q - 2 * q * d - 4 * r * d + 4 * k * d + 8 * r == 8 * n);
+        // __VERIFIER_assert(k * t == t * t);
+        // __VERIFIER_assert(d * d * q - 2 * d * q - 4 * d * r + 4 * d * t + 4 * a * k - 4 * a * t - 8 * n + 8 * r == 0);
+        // __VERIFIER_assert(d * k - d * t - a * k + a * t == 0);
+
+        if (!(d * k - d * t - a * k + a * t == 0)) break;
+
+        if (2 * r  + q < k) {
+            t = r;
+            r = 2 * r - k + q + d + 2;
+            k = t;
+            q = q + 4;
+            d = d + 2;
+        } else if ((2 * r  + q >= k) && (2 * r + q < d + k + 2)) {
+            t = r;
+            r = 2 * r - k + q;
+            k = t;
+            d = d + 2;
+        } else if ((2 * r  + q >= k) && (2 * r + q >= d + k + 2) && (2 * r + q < 2 * d + k + 4)) {
+            t = r;
+            r = 2 * r - k + q - d - 2;
+            k = t;
+            q = q - 4;
+            d = d + 2;
+        } else { /* ((2*r-k+q>=0)&&(2*r-k+q>=2*d+4)) */
+            t = r;
+            r = 2 * r - k + q - 2 * d - 4;
+            k = t;
+            q = q - 8;
+            d = d + 2;
+        }
+    }
+
+    //postconds ? cannot be obtained with DIG (Syminfer)
+    return 0;
+}

--- a/c/termination-nla/knuth-nosqrt-both-nt.i
+++ b/c/termination-nla/knuth-nosqrt-both-nt.i
@@ -1,0 +1,48 @@
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern double sqrt(double);
+int main() {
+    unsigned s, a;
+    unsigned r, k, q, d, n, t;
+    s = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_unsigned_int();
+    if (s >= 8192) {
+        return 0;
+    }
+    if (a <= 2) {
+        return 0;
+    }
+    n = s*s;
+    d = a;
+    r = n % d;
+    t = 0;
+    k = n % (d - 2);
+    q = 4 * (n / (d - 2) - n / d);
+    while (1) {
+        if (!(d * k - d * t - a * k + a * t == 0)) break;
+        if (2 * r + q < k) {
+            t = r;
+            r = 2 * r - k + q + d + 2;
+            k = t;
+            q = q + 4;
+            d = d + 2;
+        } else if ((2 * r + q >= k) && (2 * r + q < d + k + 2)) {
+            t = r;
+            r = 2 * r - k + q;
+            k = t;
+            d = d + 2;
+        } else if ((2 * r + q >= k) && (2 * r + q >= d + k + 2) && (2 * r + q < 2 * d + k + 4)) {
+            t = r;
+            r = 2 * r - k + q - d - 2;
+            k = t;
+            q = q - 4;
+            d = d + 2;
+        } else {
+            t = r;
+            r = 2 * r - k + q - 2 * d - 4;
+            k = t;
+            q = q - 8;
+            d = d + 2;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/knuth-nosqrt-both-nt.yml
+++ b/c/termination-nla/knuth-nosqrt-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'knuth-nosqrt-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/knuth-nosqrt-both-t.c
+++ b/c/termination-nla/knuth-nosqrt-both-t.c
@@ -1,0 +1,74 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* algorithm searching for a divisor for factorization, by Knuth */
+
+#include <limits.h>
+
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+
+extern double sqrt(double);
+
+int main() {
+    unsigned s, a;
+    unsigned r, k, q, d, n, t;
+    s = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_unsigned_int();
+    // assume_abort_if_not(s < 8192);
+    // assume_abort_if_not(a > 2);
+
+    if (s >= 8192) {
+        return 0;
+    }
+    if (a <= 2) {
+        return 0;
+    }
+
+    n = s*s;
+    d = a;
+    r = n % d;
+    t = 0;
+    k = n % (d - 2);
+    q = 4 * (n / (d - 2) - n / d);
+
+    while (1) {
+        // __VERIFIER_assert(d * d * q - 2 * q * d - 4 * r * d + 4 * k * d + 8 * r == 8 * n);
+        // __VERIFIER_assert(k * t == t * t);
+        // __VERIFIER_assert(d * d * q - 2 * d * q - 4 * d * r + 4 * d * t + 4 * a * k - 4 * a * t - 8 * n + 8 * r == 0);
+        // __VERIFIER_assert(d * k - d * t - a * k + a * t == 0);
+
+        if (!((s + d * k - d * t - a * k + a * t >= d) && (r != 0))) break;
+
+        if (2 * r  + q < k) {
+            t = r;
+            r = 2 * r - k + q + d + 2;
+            k = t;
+            q = q + 4;
+            d = d + 2;
+        } else if ((2 * r  + q >= k) && (2 * r + q < d + k + 2)) {
+            t = r;
+            r = 2 * r - k + q;
+            k = t;
+            d = d + 2;
+        } else if ((2 * r  + q >= k) && (2 * r + q >= d + k + 2) && (2 * r + q < 2 * d + k + 4)) {
+            t = r;
+            r = 2 * r - k + q - d - 2;
+            k = t;
+            q = q - 4;
+            d = d + 2;
+        } else { /* ((2*r-k+q>=0)&&(2*r-k+q>=2*d+4)) */
+            t = r;
+            r = 2 * r - k + q - 2 * d - 4;
+            k = t;
+            q = q - 8;
+            d = d + 2;
+        }
+    }
+
+    //postconds ? cannot be obtained with DIG (Syminfer)
+    return 0;
+}

--- a/c/termination-nla/knuth-nosqrt-both-t.i
+++ b/c/termination-nla/knuth-nosqrt-both-t.i
@@ -1,0 +1,48 @@
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+extern double sqrt(double);
+int main() {
+    unsigned s, a;
+    unsigned r, k, q, d, n, t;
+    s = __VERIFIER_nondet_unsigned_int();
+    a = __VERIFIER_nondet_unsigned_int();
+    if (s >= 8192) {
+        return 0;
+    }
+    if (a <= 2) {
+        return 0;
+    }
+    n = s*s;
+    d = a;
+    r = n % d;
+    t = 0;
+    k = n % (d - 2);
+    q = 4 * (n / (d - 2) - n / d);
+    while (1) {
+        if (!((s + d * k - d * t - a * k + a * t >= d) && (r != 0))) break;
+        if (2 * r + q < k) {
+            t = r;
+            r = 2 * r - k + q + d + 2;
+            k = t;
+            q = q + 4;
+            d = d + 2;
+        } else if ((2 * r + q >= k) && (2 * r + q < d + k + 2)) {
+            t = r;
+            r = 2 * r - k + q;
+            k = t;
+            d = d + 2;
+        } else if ((2 * r + q >= k) && (2 * r + q >= d + k + 2) && (2 * r + q < 2 * d + k + 4)) {
+            t = r;
+            r = 2 * r - k + q - d - 2;
+            k = t;
+            q = q - 4;
+            d = d + 2;
+        } else {
+            t = r;
+            r = 2 * r - k + q - 2 * d - 4;
+            k = t;
+            q = q - 8;
+            d = d + 2;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/knuth-nosqrt-both-t.yml
+++ b/c/termination-nla/knuth-nosqrt-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'knuth-nosqrt-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/lcm1-both-nt.c
+++ b/c/termination-nla/lcm1-both-nt.c
@@ -1,0 +1,63 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+ * algorithm for computing simultaneously the GCD and the LCM,
+ * by Sankaranarayanan
+ */
+
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+
+int main() {
+    unsigned a, b;
+    unsigned x, y, u, v;
+    a = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_unsigned_int();
+    // assume_abort_if_not(a >= 1);  //infinite loop if remove
+    // assume_abort_if_not(b >= 1);
+
+    // assume_abort_if_not(a <= 65535);
+    // assume_abort_if_not(b <= 65535);
+
+    if (a < 1 || b < 1 || a > 65535 || b > 65535) {
+        return 0;
+    }
+
+    x = a;
+    y = b;
+    u = b;
+    v = 0;
+
+    while (1) {
+        // __VERIFIER_assert(x*u + y*v == a*b);
+        if (!(x*u + y*v == a*b))
+            break;
+
+        while (1) {
+	    // __VERIFIER_assert(x*u + y*v == a*b);
+            if (!(x*u + y*v == a*b))
+                break;
+            x = x - y;
+            v = v + u;
+        }
+
+        while (1) {
+	    // __VERIFIER_assert(x*u + y*v == a*b);
+            if (!(x*u + y*v == a*b))
+                break;
+            y = y - x;
+            u = u + v;
+        }
+    }
+
+    // __VERIFIER_assert(u*y + v*y == a*b);
+    // __VERIFIER_assert(x == y);
+
+    //x == gcd(a,b)
+    //u + v == lcm(a,b)
+    return 0;
+}

--- a/c/termination-nla/lcm1-both-nt.i
+++ b/c/termination-nla/lcm1-both-nt.i
@@ -1,0 +1,31 @@
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+int main() {
+    unsigned a, b;
+    unsigned x, y, u, v;
+    a = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_unsigned_int();
+    if (a < 1 || b < 1 || a > 65535 || b > 65535) {
+        return 0;
+    }
+    x = a;
+    y = b;
+    u = b;
+    v = 0;
+    while (1) {
+        if (!(x*u + y*v == a*b))
+            break;
+        while (1) {
+            if (!(x*u + y*v == a*b))
+                break;
+            x = x - y;
+            v = v + u;
+        }
+        while (1) {
+            if (!(x*u + y*v == a*b))
+                break;
+            y = y - x;
+            u = u + v;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/lcm1-both-nt.yml
+++ b/c/termination-nla/lcm1-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'lcm1-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/lcm1-both-t.c
+++ b/c/termination-nla/lcm1-both-t.c
@@ -1,0 +1,63 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/*
+ * algorithm for computing simultaneously the GCD and the LCM,
+ * by Sankaranarayanan
+ */
+
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+
+int main() {
+    unsigned a, b;
+    unsigned x, y, u, v;
+    a = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_unsigned_int();
+    // assume_abort_if_not(a >= 1);  //infinite loop if remove
+    // assume_abort_if_not(b >= 1);
+
+    // assume_abort_if_not(a <= 65535);
+    // assume_abort_if_not(b <= 65535);
+
+    if (a < 1 || b < 1 || a > 65535 || b > 65535) {
+        return 0;
+    }
+
+    x = a;
+    y = b;
+    u = b;
+    v = 0;
+
+    while (1) {
+        // __VERIFIER_assert(x*u + y*v == a*b);
+        if (!(x != y + x*u + y*v - a*b))
+            break;
+
+        while (1) {
+	    // __VERIFIER_assert(x*u + y*v == a*b);
+            if (!(x > y + x*u + y*v - a*b))
+                break;
+            x = x - y;
+            v = v + u;
+        }
+
+        while (1) {
+	    // __VERIFIER_assert(x*u + y*v == a*b);
+            if (!(x < y + x*u + y*v - a*b))
+                break;
+            y = y - x;
+            u = u + v;
+        }
+    }
+
+    // __VERIFIER_assert(u*y + v*y == a*b);
+    // __VERIFIER_assert(x == y);
+
+    //x == gcd(a,b)
+    //u + v == lcm(a,b)
+    return 0;
+}

--- a/c/termination-nla/lcm1-both-t.i
+++ b/c/termination-nla/lcm1-both-t.i
@@ -1,0 +1,31 @@
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+int main() {
+    unsigned a, b;
+    unsigned x, y, u, v;
+    a = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_unsigned_int();
+    if (a < 1 || b < 1 || a > 65535 || b > 65535) {
+        return 0;
+    }
+    x = a;
+    y = b;
+    u = b;
+    v = 0;
+    while (1) {
+        if (!(x != y + x*u + y*v - a*b))
+            break;
+        while (1) {
+            if (!(x > y + x*u + y*v - a*b))
+                break;
+            x = x - y;
+            v = v + u;
+        }
+        while (1) {
+            if (!(x < y + x*u + y*v - a*b))
+                break;
+            y = y - x;
+            u = u + v;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/lcm1-both-t.yml
+++ b/c/termination-nla/lcm1-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'lcm1-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/lcm2-both-nt.c
+++ b/c/termination-nla/lcm2-both-nt.c
@@ -1,0 +1,52 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
+
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+
+int main() {
+    int a, b;
+    int x, y, u, v;
+    a = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_unsigned_int();
+    // assume_abort_if_not(a >= 1); //inf loop if remove
+    // assume_abort_if_not(b >= 1);
+
+    // assume_abort_if_not(a <= 65535);
+    // assume_abort_if_not(b <= 65535);
+
+    if (a < 1 || b < 1 || a > 65535 || b > 65535) {
+        return 0;
+    }
+
+    x = a;
+    y = b;
+    u = b;
+    v = a;
+
+    while (1) {
+        // __VERIFIER_assert(x*u + y*v == 2*a*b);
+
+        if (!(x*u + y*v == 2*a*b))
+            break;
+
+        if (x > y) {
+            x = x - y;
+            v = v + u;
+        } else {
+            y = y - x;
+            u = u + v;
+        }
+    }
+
+    // __VERIFIER_assert(x*u + y*v == 2*a*b);
+    // x == gcd(a,b)
+    //(u + v)/2==lcm(a,b)
+
+    return 0;
+}

--- a/c/termination-nla/lcm2-both-nt.i
+++ b/c/termination-nla/lcm2-both-nt.i
@@ -1,0 +1,26 @@
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+int main() {
+    int a, b;
+    int x, y, u, v;
+    a = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_unsigned_int();
+    if (a < 1 || b < 1 || a > 65535 || b > 65535) {
+        return 0;
+    }
+    x = a;
+    y = b;
+    u = b;
+    v = a;
+    while (1) {
+        if (!(x*u + y*v == 2*a*b))
+            break;
+        if (x > y) {
+            x = x - y;
+            v = v + u;
+        } else {
+            y = y - x;
+            u = u + v;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/lcm2-both-nt.yml
+++ b/c/termination-nla/lcm2-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'lcm2-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/lcm2-both-t.c
+++ b/c/termination-nla/lcm2-both-t.c
@@ -1,0 +1,52 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* Algorithm for computing simultaneously the GCD and the LCM, by Dijkstra */
+
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+
+int main() {
+    int a, b;
+    int x, y, u, v;
+    a = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_unsigned_int();
+    // assume_abort_if_not(a >= 1); //inf loop if remove
+    // assume_abort_if_not(b >= 1);
+
+    // assume_abort_if_not(a <= 65535);
+    // assume_abort_if_not(b <= 65535);
+
+    if (a < 1 || b < 1 || a > 65535 || b > 65535) {
+        return 0;
+    }
+
+    x = a;
+    y = b;
+    u = b;
+    v = a;
+
+    while (1) {
+        // __VERIFIER_assert(x*u + y*v == 2*a*b);
+
+        if (!(x != y + x*u + y*v - 2*a*b))
+            break;
+
+        if (x > y) {
+            x = x - y;
+            v = v + u;
+        } else {
+            y = y - x;
+            u = u + v;
+        }
+    }
+
+    // __VERIFIER_assert(x*u + y*v == 2*a*b);
+    // x == gcd(a,b)
+    //(u + v)/2==lcm(a,b)
+
+    return 0;
+}

--- a/c/termination-nla/lcm2-both-t.i
+++ b/c/termination-nla/lcm2-both-t.i
@@ -1,0 +1,26 @@
+extern unsigned __VERIFIER_nondet_unsigned_int(void);
+int main() {
+    int a, b;
+    int x, y, u, v;
+    a = __VERIFIER_nondet_unsigned_int();
+    b = __VERIFIER_nondet_unsigned_int();
+    if (a < 1 || b < 1 || a > 65535 || b > 65535) {
+        return 0;
+    }
+    x = a;
+    y = b;
+    u = b;
+    v = a;
+    while (1) {
+        if (!(x != y + x*u + y*v - 2*a*b))
+            break;
+        if (x > y) {
+            x = x - y;
+            v = v + u;
+        } else {
+            y = y - x;
+            u = u + v;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/lcm2-both-t.yml
+++ b/c/termination-nla/lcm2-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'lcm2-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/mannadiv-both-nt.c
+++ b/c/termination-nla/mannadiv-both-nt.c
@@ -1,0 +1,49 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* 
+ Division algorithm from
+ "Z. Manna, Mathematical Theory of Computation, McGraw-Hill, 1974"
+ return x1 // x2
+*/
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int x1, x2;
+    int y1, y2, y3;
+    x1 = __VERIFIER_nondet_int();
+    x2 = __VERIFIER_nondet_int();
+
+    // assume_abort_if_not(x1 >= 0);
+    // assume_abort_if_not(x2 != 0);
+
+    if (x1 < 0 || x2 == 0) {
+        return 0;
+    }
+
+    y1 = 0;
+    y2 = 0;
+    y3 = x1;
+
+    while (1) {
+        // __VERIFIER_assert(y1*x2 + y2 + y3 == x1);
+
+        if (!(y1*x2 + y2 + y3 == x1)) break;
+
+        if (y2 + 1 == x2) {
+            y1 = y1 + 1;
+            y2 = 0;
+            y3 = y3 - 1;
+        } else {
+            y2 = y2 + 1;
+            y3 = y3 - 1;
+        }
+    }
+    // __VERIFIER_assert(y1*x2 + y2 == x1);
+    return 0;
+}

--- a/c/termination-nla/mannadiv-both-nt.i
+++ b/c/termination-nla/mannadiv-both-nt.i
@@ -1,0 +1,25 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int x1, x2;
+    int y1, y2, y3;
+    x1 = __VERIFIER_nondet_int();
+    x2 = __VERIFIER_nondet_int();
+    if (x1 < 0 || x2 == 0) {
+        return 0;
+    }
+    y1 = 0;
+    y2 = 0;
+    y3 = x1;
+    while (1) {
+        if (!(y1*x2 + y2 + y3 == x1)) break;
+        if (y2 + 1 == x2) {
+            y1 = y1 + 1;
+            y2 = 0;
+            y3 = y3 - 1;
+        } else {
+            y2 = y2 + 1;
+            y3 = y3 - 1;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/mannadiv-both-nt.yml
+++ b/c/termination-nla/mannadiv-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'mannadiv-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/mannadiv-both-t.c
+++ b/c/termination-nla/mannadiv-both-t.c
@@ -1,0 +1,49 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* 
+ Division algorithm from
+ "Z. Manna, Mathematical Theory of Computation, McGraw-Hill, 1974"
+ return x1 // x2
+*/
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int x1, x2;
+    int y1, y2, y3;
+    x1 = __VERIFIER_nondet_int();
+    x2 = __VERIFIER_nondet_int();
+
+    // assume_abort_if_not(x1 >= 0);
+    // assume_abort_if_not(x2 != 0);
+
+    if (x1 < 0 || x2 == 0) {
+        return 0;
+    }
+
+    y1 = 0;
+    y2 = 0;
+    y3 = x1;
+
+    while (1) {
+        // __VERIFIER_assert(y1*x2 + y2 + y3 == x1);
+
+        if (!(y3 != y1*x2 + y2 + y3 - x1)) break;
+
+        if (y2 + 1 == x2) {
+            y1 = y1 + 1;
+            y2 = 0;
+            y3 = y3 - 1;
+        } else {
+            y2 = y2 + 1;
+            y3 = y3 - 1;
+        }
+    }
+    // __VERIFIER_assert(y1*x2 + y2 == x1);
+    return 0;
+}

--- a/c/termination-nla/mannadiv-both-t.i
+++ b/c/termination-nla/mannadiv-both-t.i
@@ -1,0 +1,25 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int x1, x2;
+    int y1, y2, y3;
+    x1 = __VERIFIER_nondet_int();
+    x2 = __VERIFIER_nondet_int();
+    if (x1 < 0 || x2 == 0) {
+        return 0;
+    }
+    y1 = 0;
+    y2 = 0;
+    y3 = x1;
+    while (1) {
+        if (!(y3 != y1*x2 + y2 + y3 - x1)) break;
+        if (y2 + 1 == x2) {
+            y1 = y1 + 1;
+            y2 = 0;
+            y3 = y3 - 1;
+        } else {
+            y2 = y2 + 1;
+            y3 = y3 - 1;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/mannadiv-both-t.yml
+++ b/c/termination-nla/mannadiv-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'mannadiv-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/prod4br-both-nt.c
+++ b/c/termination-nla/prod4br-both-nt.c
@@ -1,0 +1,55 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* algorithm for computing the product of two natural numbers */
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int x, y;
+    int a, b, p, q;
+
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    // assume_abort_if_not(y >= 1);
+
+    if (y < 1) {
+        return 0;
+    }
+
+    a = x;
+    b = y;
+    p = 1;
+    q = 0;
+
+    while (1) {
+        // __VERIFIER_assert(q + a * b * p == x * y);
+
+        if (!(q + a * b * p == x * y))
+            break;
+
+        if (a % 2 == 0 && b % 2 == 0) {
+            a = a / 2;
+            b = b / 2;
+            p = 4 * p;
+        } else if (a % 2 == 1 && b % 2 == 0) {
+            a = a - 1;
+            q = q + b * p;
+        } else if (a % 2 == 0 && b % 2 == 1) {
+            b = b - 1;
+            q = q + a * p;
+        } else {
+            a = a - 1;
+            b = b - 1;
+            q = q + (a + b + 1) * p; /*fix a bug here---  was (a+b-1)*/
+        }
+    }
+
+    // __VERIFIER_assert(q == x * y);
+    // __VERIFIER_assert(a * b == 0);
+    return 0;
+}

--- a/c/termination-nla/prod4br-both-nt.i
+++ b/c/termination-nla/prod4br-both-nt.i
@@ -1,0 +1,34 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int x, y;
+    int a, b, p, q;
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    if (y < 1) {
+        return 0;
+    }
+    a = x;
+    b = y;
+    p = 1;
+    q = 0;
+    while (1) {
+        if (!(q + a * b * p == x * y))
+            break;
+        if (a % 2 == 0 && b % 2 == 0) {
+            a = a / 2;
+            b = b / 2;
+            p = 4 * p;
+        } else if (a % 2 == 1 && b % 2 == 0) {
+            a = a - 1;
+            q = q + b * p;
+        } else if (a % 2 == 0 && b % 2 == 1) {
+            b = b - 1;
+            q = q + a * p;
+        } else {
+            a = a - 1;
+            b = b - 1;
+            q = q + (a + b + 1) * p;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/prod4br-both-nt.yml
+++ b/c/termination-nla/prod4br-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'prod4br-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/prod4br-both-t.c
+++ b/c/termination-nla/prod4br-both-t.c
@@ -1,0 +1,55 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* algorithm for computing the product of two natural numbers */
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int x, y;
+    int a, b, p, q;
+
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    // assume_abort_if_not(y >= 1);
+
+    if (y < 1) {
+        return 0;
+    }
+
+    a = x;
+    b = y;
+    p = 1;
+    q = 0;
+
+    while (1) {
+        // __VERIFIER_assert(q + a * b * p == x * y);
+
+        if (!(a != 0 && b + q + a * b * p - x * y != 0))
+            break;
+
+        if (a % 2 == 0 && b % 2 == 0) {
+            a = a / 2;
+            b = b / 2;
+            p = 4 * p;
+        } else if (a % 2 == 1 && b % 2 == 0) {
+            a = a - 1;
+            q = q + b * p;
+        } else if (a % 2 == 0 && b % 2 == 1) {
+            b = b - 1;
+            q = q + a * p;
+        } else {
+            a = a - 1;
+            b = b - 1;
+            q = q + (a + b + 1) * p; /*fix a bug here---  was (a+b-1)*/
+        }
+    }
+
+    // __VERIFIER_assert(q == x * y);
+    // __VERIFIER_assert(a * b == 0);
+    return 0;
+}

--- a/c/termination-nla/prod4br-both-t.i
+++ b/c/termination-nla/prod4br-both-t.i
@@ -1,0 +1,34 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int x, y;
+    int a, b, p, q;
+    x = __VERIFIER_nondet_int();
+    y = __VERIFIER_nondet_int();
+    if (y < 1) {
+        return 0;
+    }
+    a = x;
+    b = y;
+    p = 1;
+    q = 0;
+    while (1) {
+        if (!(a != 0 && b + q + a * b * p - x * y != 0))
+            break;
+        if (a % 2 == 0 && b % 2 == 0) {
+            a = a / 2;
+            b = b / 2;
+            p = 4 * p;
+        } else if (a % 2 == 1 && b % 2 == 0) {
+            a = a - 1;
+            q = q + b * p;
+        } else if (a % 2 == 0 && b % 2 == 1) {
+            b = b - 1;
+            q = q + a * p;
+        } else {
+            a = a - 1;
+            b = b - 1;
+            q = q + (a + b + 1) * p;
+        }
+    }
+    return 0;
+}

--- a/c/termination-nla/prod4br-both-t.yml
+++ b/c/termination-nla/prod4br-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'prod4br-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/prodbin-both-nt.c
+++ b/c/termination-nla/prodbin-both-nt.c
@@ -1,0 +1,44 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* shift_add algorithm for computing the 
+   product of two natural numbers
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, b;
+    int x, y, z;
+
+    a = __VERIFIER_nondet_int();
+    b = __VERIFIER_nondet_int();
+    // assume_abort_if_not(b >= 1);
+
+    if (b < 1) {
+        return 0;
+    }
+
+    x = a;
+    y = b;
+    z = 0;
+
+    while (1) {
+        // __VERIFIER_assert(z + x * y == a * b);
+        if (!(z + x * y == a * b))
+            break;
+
+        if (y % 2 == 1) {
+            z = z + x;
+            y = y - 1;
+        }
+        x = 2 * x;
+        y = y / 2;
+    }
+    // __VERIFIER_assert(z == a * b);
+    
+    return 0;
+}

--- a/c/termination-nla/prodbin-both-nt.i
+++ b/c/termination-nla/prodbin-both-nt.i
@@ -1,0 +1,24 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, b;
+    int x, y, z;
+    a = __VERIFIER_nondet_int();
+    b = __VERIFIER_nondet_int();
+    if (b < 1) {
+        return 0;
+    }
+    x = a;
+    y = b;
+    z = 0;
+    while (1) {
+        if (!(z + x * y == a * b))
+            break;
+        if (y % 2 == 1) {
+            z = z + x;
+            y = y - 1;
+        }
+        x = 2 * x;
+        y = y / 2;
+    }
+    return 0;
+}

--- a/c/termination-nla/prodbin-both-nt.yml
+++ b/c/termination-nla/prodbin-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'prodbin-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/prodbin-both-t.c
+++ b/c/termination-nla/prodbin-both-t.c
@@ -1,0 +1,44 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+/* shift_add algorithm for computing the 
+   product of two natural numbers
+*/
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int a, b;
+    int x, y, z;
+
+    a = __VERIFIER_nondet_int();
+    b = __VERIFIER_nondet_int();
+    // assume_abort_if_not(b >= 1);
+
+    if (b < 1) {
+        return 0;
+    }
+
+    x = a;
+    y = b;
+    z = 0;
+
+    while (1) {
+        // __VERIFIER_assert(z + x * y == a * b);
+        if (!(y + z + x * y - a * b != 0))
+            break;
+
+        if (y % 2 == 1) {
+            z = z + x;
+            y = y - 1;
+        }
+        x = 2 * x;
+        y = y / 2;
+    }
+    // __VERIFIER_assert(z == a * b);
+    
+    return 0;
+}

--- a/c/termination-nla/prodbin-both-t.i
+++ b/c/termination-nla/prodbin-both-t.i
@@ -1,0 +1,24 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int a, b;
+    int x, y, z;
+    a = __VERIFIER_nondet_int();
+    b = __VERIFIER_nondet_int();
+    if (b < 1) {
+        return 0;
+    }
+    x = a;
+    y = b;
+    z = 0;
+    while (1) {
+        if (!(y + z + x * y - a * b != 0))
+            break;
+        if (y % 2 == 1) {
+            z = z + x;
+            y = y - 1;
+        }
+        x = 2 * x;
+        y = y / 2;
+    }
+    return 0;
+}

--- a/c/termination-nla/prodbin-both-t.yml
+++ b/c/termination-nla/prodbin-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'prodbin-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/ps2-both-nt.c
+++ b/c/termination-nla/ps2-both-nt.c
@@ -1,0 +1,32 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+
+    y = 0;
+    x = 0;
+    c = 0;
+
+    while (1) {
+        // __VERIFIER_assert((y * y) - 2 * x + y == 0);
+
+        if (!((y * y) - 2 * x + y == 0))
+            break;
+
+        c = c + 1;
+        y = y + 1;
+        x = y + x;
+    }
+    // __VERIFIER_assert((y*y) - 2*x + y == 0);
+     
+    return 0;
+}

--- a/c/termination-nla/ps2-both-nt.i
+++ b/c/termination-nla/ps2-both-nt.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+    y = 0;
+    x = 0;
+    c = 0;
+    while (1) {
+        if (!((y * y) - 2 * x + y == 0))
+            break;
+        c = c + 1;
+        y = y + 1;
+        x = y + x;
+    }
+    return 0;
+}

--- a/c/termination-nla/ps2-both-nt.yml
+++ b/c/termination-nla/ps2-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'ps2-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/ps2-both-t.c
+++ b/c/termination-nla/ps2-both-t.c
@@ -1,0 +1,32 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+
+    y = 0;
+    x = 0;
+    c = 0;
+
+    while (1) {
+        // __VERIFIER_assert((y * y) - 2 * x + y == 0);
+
+        if (!(c + (y * y) - 2 * x + y < k))
+            break;
+
+        c = c + 1;
+        y = y + 1;
+        x = y + x;
+    }
+    // __VERIFIER_assert((y*y) - 2*x + y == 0);
+     
+    return 0;
+}

--- a/c/termination-nla/ps2-both-t.i
+++ b/c/termination-nla/ps2-both-t.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+    y = 0;
+    x = 0;
+    c = 0;
+    while (1) {
+        if (!(c + (y * y) - 2 * x + y < k))
+            break;
+        c = c + 1;
+        y = y + 1;
+        x = y + x;
+    }
+    return 0;
+}

--- a/c/termination-nla/ps2-both-t.yml
+++ b/c/termination-nla/ps2-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'ps2-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/ps3-both-nt.c
+++ b/c/termination-nla/ps3-both-nt.c
@@ -1,0 +1,31 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+
+    y = 0;
+    x = 0;
+    c = 0;
+
+    while (1) {
+        // __VERIFIER_assert(6*x - 2*y*y*y - 3*y*y - y == 0);
+
+        if (!(6*x - 2*y*y*y - 3*y*y - y == 0))
+            break;
+
+        c = c + 1;
+        y = y + 1;
+        x = y * y + x;
+    }
+    // __VERIFIER_assert(6*x - 2*y*y*y - 3*y*y - y == 0);
+    return 0;
+}

--- a/c/termination-nla/ps3-both-nt.i
+++ b/c/termination-nla/ps3-both-nt.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+    y = 0;
+    x = 0;
+    c = 0;
+    while (1) {
+        if (!(6*x - 2*y*y*y - 3*y*y - y == 0))
+            break;
+        c = c + 1;
+        y = y + 1;
+        x = y * y + x;
+    }
+    return 0;
+}

--- a/c/termination-nla/ps3-both-nt.yml
+++ b/c/termination-nla/ps3-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'ps3-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/ps3-both-t.c
+++ b/c/termination-nla/ps3-both-t.c
@@ -1,0 +1,31 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+
+    y = 0;
+    x = 0;
+    c = 0;
+
+    while (1) {
+        // __VERIFIER_assert(6*x - 2*y*y*y - 3*y*y - y == 0);
+
+        if (!(c + 6*x - 2*y*y*y - 3*y*y - y < k))
+            break;
+
+        c = c + 1;
+        y = y + 1;
+        x = y * y + x;
+    }
+    // __VERIFIER_assert(6*x - 2*y*y*y - 3*y*y - y == 0);
+    return 0;
+}

--- a/c/termination-nla/ps3-both-t.i
+++ b/c/termination-nla/ps3-both-t.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+    y = 0;
+    x = 0;
+    c = 0;
+    while (1) {
+        if (!(c + 6*x - 2*y*y*y - 3*y*y - y < k))
+            break;
+        c = c + 1;
+        y = y + 1;
+        x = y * y + x;
+    }
+    return 0;
+}

--- a/c/termination-nla/ps3-both-t.yml
+++ b/c/termination-nla/ps3-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'ps3-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/ps4-both-nt.c
+++ b/c/termination-nla/ps4-both-nt.c
@@ -1,0 +1,32 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+
+    y = 0;
+    x = 0;
+    c = 0;
+
+    while (1) {
+        // __VERIFIER_assert(4*x - y*y*y*y - 2*y*y*y - y*y == 0);
+
+        if (!(4*x - y*y*y*y - 2*y*y*y - y*y == 0))
+            break;
+
+        c = c + 1;
+        y = y + 1;
+        x = y * y * y + x;
+    }
+    // __VERIFIER_assert(k*y - (y*y) == 0);
+    // __VERIFIER_assert(4*x - y*y*y*y - 2*y*y*y - y*y == 0);
+    return 0;
+}

--- a/c/termination-nla/ps4-both-nt.i
+++ b/c/termination-nla/ps4-both-nt.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+    y = 0;
+    x = 0;
+    c = 0;
+    while (1) {
+        if (!(4*x - y*y*y*y - 2*y*y*y - y*y == 0))
+            break;
+        c = c + 1;
+        y = y + 1;
+        x = y * y * y + x;
+    }
+    return 0;
+}

--- a/c/termination-nla/ps4-both-nt.yml
+++ b/c/termination-nla/ps4-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'ps4-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/ps4-both-t.c
+++ b/c/termination-nla/ps4-both-t.c
@@ -1,0 +1,32 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+
+    y = 0;
+    x = 0;
+    c = 0;
+
+    while (1) {
+        // __VERIFIER_assert(4*x - y*y*y*y - 2*y*y*y - y*y == 0);
+
+        if (!(c + 4*x - y*y*y*y - 2*y*y*y - y*y < k))
+            break;
+
+        c = c + 1;
+        y = y + 1;
+        x = y * y * y + x;
+    }
+    // __VERIFIER_assert(k*y - (y*y) == 0);
+    // __VERIFIER_assert(4*x - y*y*y*y - 2*y*y*y - y*y == 0);
+    return 0;
+}

--- a/c/termination-nla/ps4-both-t.i
+++ b/c/termination-nla/ps4-both-t.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+    y = 0;
+    x = 0;
+    c = 0;
+    while (1) {
+        if (!(c + 4*x - y*y*y*y - 2*y*y*y - y*y < k))
+            break;
+        c = c + 1;
+        y = y + 1;
+        x = y * y * y + x;
+    }
+    return 0;
+}

--- a/c/termination-nla/ps4-both-t.yml
+++ b/c/termination-nla/ps4-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'ps4-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/ps5-both-nt.c
+++ b/c/termination-nla/ps5-both-nt.c
@@ -1,0 +1,32 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+
+    y = 0;
+    x = 0;
+    c = 0;
+
+    while (1) {
+        // __VERIFIER_assert(6*y*y*y*y*y + 15*y*y*y*y + 10*y*y*y - 30*x - y == 0);
+
+        if (!(6*y*y*y*y*y + 15*y*y*y*y + 10*y*y*y - 30*x - y == 0))
+            break;
+
+        c = c + 1;
+        y = y + 1;
+        x = y * y * y * y + x;
+    }
+
+    // __VERIFIER_assert(6*y*y*y*y*y + 15*y*y*y*y + 10*y*y*y - 30*x - y == 0);
+    // __VERIFIER_assert(k*y == y*y);
+    return 0;
+}

--- a/c/termination-nla/ps5-both-nt.i
+++ b/c/termination-nla/ps5-both-nt.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+    y = 0;
+    x = 0;
+    c = 0;
+    while (1) {
+        if (!(6*y*y*y*y*y + 15*y*y*y*y + 10*y*y*y - 30*x - y == 0))
+            break;
+        c = c + 1;
+        y = y + 1;
+        x = y * y * y * y + x;
+    }
+    return 0;
+}

--- a/c/termination-nla/ps5-both-nt.yml
+++ b/c/termination-nla/ps5-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'ps5-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/ps5-both-t.c
+++ b/c/termination-nla/ps5-both-t.c
@@ -1,0 +1,32 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+
+    y = 0;
+    x = 0;
+    c = 0;
+
+    while (1) {
+        // __VERIFIER_assert(6*y*y*y*y*y + 15*y*y*y*y + 10*y*y*y - 30*x - y == 0);
+
+        if (!(c + 6*y*y*y*y*y + 15*y*y*y*y + 10*y*y*y - 30*x - y < k))
+            break;
+
+        c = c + 1;
+        y = y + 1;
+        x = y * y * y * y + x;
+    }
+
+    // __VERIFIER_assert(6*y*y*y*y*y + 15*y*y*y*y + 10*y*y*y - 30*x - y == 0);
+    // __VERIFIER_assert(k*y == y*y);
+    return 0;
+}

--- a/c/termination-nla/ps5-both-t.i
+++ b/c/termination-nla/ps5-both-t.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+    y = 0;
+    x = 0;
+    c = 0;
+    while (1) {
+        if (!(c + 6*y*y*y*y*y + 15*y*y*y*y + 10*y*y*y - 30*x - y < k))
+            break;
+        c = c + 1;
+        y = y + 1;
+        x = y * y * y * y + x;
+    }
+    return 0;
+}

--- a/c/termination-nla/ps5-both-t.yml
+++ b/c/termination-nla/ps5-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'ps5-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/ps6-both-nt.c
+++ b/c/termination-nla/ps6-both-nt.c
@@ -1,0 +1,32 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+
+    y = 0;
+    x = 0;
+    c = 0;
+
+    while (1) {
+        // __VERIFIER_assert(-2*y*y*y*y*y*y - 6 * y*y*y*y*y - 5 * y*y*y*y + y*y + 12*x == 0);
+
+        if (!(-2*y*y*y*y*y*y - 6 * y*y*y*y*y - 5 * y*y*y*y + y*y + 12*x == 0))
+            break;
+
+        c = c + 1;
+        y = y + 1;
+        x = y * y * y * y * y + x;
+    }
+    
+    // __VERIFIER_assert(-2*y*y*y*y*y*y - 6 * y*y*y*y*y - 5 * y*y*y*y + y*y + 12*x == 0);
+    // __VERIFIER_assert(k*y == y*y);      
+    return 0;
+}

--- a/c/termination-nla/ps6-both-nt.i
+++ b/c/termination-nla/ps6-both-nt.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+    y = 0;
+    x = 0;
+    c = 0;
+    while (1) {
+        if (!(-2*y*y*y*y*y*y - 6 * y*y*y*y*y - 5 * y*y*y*y + y*y + 12*x == 0))
+            break;
+        c = c + 1;
+        y = y + 1;
+        x = y * y * y * y * y + x;
+    }
+    return 0;
+}

--- a/c/termination-nla/ps6-both-nt.yml
+++ b/c/termination-nla/ps6-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'ps6-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/ps6-both-t.c
+++ b/c/termination-nla/ps6-both-t.c
@@ -1,0 +1,32 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+
+    y = 0;
+    x = 0;
+    c = 0;
+
+    while (1) {
+        // __VERIFIER_assert(-2*y*y*y*y*y*y - 6 * y*y*y*y*y - 5 * y*y*y*y + y*y + 12*x == 0);
+
+        if (!(c + -2*y*y*y*y*y*y - 6 * y*y*y*y*y - 5 * y*y*y*y + y*y + 12*x < k))
+            break;
+
+        c = c + 1;
+        y = y + 1;
+        x = y * y * y * y * y + x;
+    }
+    
+    // __VERIFIER_assert(-2*y*y*y*y*y*y - 6 * y*y*y*y*y - 5 * y*y*y*y + y*y + 12*x == 0);
+    // __VERIFIER_assert(k*y == y*y);      
+    return 0;
+}

--- a/c/termination-nla/ps6-both-t.i
+++ b/c/termination-nla/ps6-both-t.i
@@ -1,0 +1,16 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int k, y, x, c;
+    k = __VERIFIER_nondet_int();
+    y = 0;
+    x = 0;
+    c = 0;
+    while (1) {
+        if (!(c + -2*y*y*y*y*y*y - 6 * y*y*y*y*y - 5 * y*y*y*y + y*y + 12*x < k))
+            break;
+        c = c + 1;
+        y = y + 1;
+        x = y * y * y * y * y + x;
+    }
+    return 0;
+}

--- a/c/termination-nla/ps6-both-t.yml
+++ b/c/termination-nla/ps6-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'ps6-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/sqrt1-both-nt.c
+++ b/c/termination-nla/sqrt1-both-nt.c
@@ -1,0 +1,36 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+// https://github.com/sosy-lab/sv-benchmarks/blob/master/c/nla-digbench/sqrt1.c
+/* Compute the floor of the square root of a natural number */
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int n, a, s, t;
+    n = __VERIFIER_nondet_int();
+
+    a = 0;
+    s = 1;
+    t = 1;
+
+    while (t*t - 4*s + 2*t + 1 == 0) {
+      //__VERIFIER_assert(t == 2*a + 1);
+      //__VERIFIER_assert(s == (a + 1) * (a + 1));
+      //__VERIFIER_assert(t*t - 4*s + 2*t + 1 == 0);
+        // the above 2 should be equiv to 
+      //if (!(s <= n))break;
+        a = a + 1;
+        t = t + 2;
+        s = s + t;
+    }
+    
+    //__VERIFIER_assert(t == 2 * a + 1);
+    //__VERIFIER_assert(s == (a + 1) * (a + 1));
+    //__VERIFIER_assert(t*t - 4*s + 2*t + 1 == 0);
+
+    return 0;
+}

--- a/c/termination-nla/sqrt1-both-nt.i
+++ b/c/termination-nla/sqrt1-both-nt.i
@@ -1,0 +1,14 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int n, a, s, t;
+    n = __VERIFIER_nondet_int();
+    a = 0;
+    s = 1;
+    t = 1;
+    while (t*t - 4*s + 2*t + 1 == 0) {
+        a = a + 1;
+        t = t + 2;
+        s = s + t;
+    }
+    return 0;
+}

--- a/c/termination-nla/sqrt1-both-nt.yml
+++ b/c/termination-nla/sqrt1-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'sqrt1-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/sqrt1-both-t.c
+++ b/c/termination-nla/sqrt1-both-t.c
@@ -1,0 +1,39 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+// https://github.com/sosy-lab/sv-benchmarks/blob/master/c/nla-digbench/sqrt1.c
+/* Compute the floor of the square root of a natural number */
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int n, a, s, t, k, c;
+    n = __VERIFIER_nondet_int();
+    k = __VERIFIER_nondet_int();
+
+    a = 0;
+    s = 1;
+    t = 1;
+    c = 0;
+
+    while (t*t - 4*s + 2*t + 1 + c <= k) {
+      //__VERIFIER_assert(t == 2*a + 1);
+      //__VERIFIER_assert(s == (a + 1) * (a + 1));
+      //__VERIFIER_assert(t*t - 4*s + 2*t + 1 == 0);
+        // the above 2 should be equiv to 
+      //if (!(s <= n))break;
+        a = a + 1;
+        t = t + 2;
+        s = s + t;
+	c = c + 1;
+    }
+    
+    //__VERIFIER_assert(t == 2 * a + 1);
+    //__VERIFIER_assert(s == (a + 1) * (a + 1));
+    //__VERIFIER_assert(t*t - 4*s + 2*t + 1 == 0);
+
+    return 0;
+}

--- a/c/termination-nla/sqrt1-both-t.i
+++ b/c/termination-nla/sqrt1-both-t.i
@@ -1,0 +1,17 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int n, a, s, t, k, c;
+    n = __VERIFIER_nondet_int();
+    k = __VERIFIER_nondet_int();
+    a = 0;
+    s = 1;
+    t = 1;
+    c = 0;
+    while (t*t - 4*s + 2*t + 1 + c <= k) {
+        a = a + 1;
+        t = t + 2;
+        s = s + t;
+ c = c + 1;
+    }
+    return 0;
+}

--- a/c/termination-nla/sqrt1-both-t.yml
+++ b/c/termination-nla/sqrt1-both-t.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'sqrt1-both-t.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: true
+
+options:
+  language: C
+  data_model: ILP32

--- a/c/termination-nla/sqrt2-both-nt.c
+++ b/c/termination-nla/sqrt2-both-nt.c
@@ -1,0 +1,45 @@
+/*
+  A nonlinear termination benchmark program from the OOPSLA'20 paper 
+  "DynamiTe: Dynamic termination and non-termination proofs"
+  by Ton Chanh Le, Timos Antonopoulos, Parisa Fathololumi, Eric Koskinen, ThanhVu Nguyen.
+  Adapted from the original nonlinear benchmark nla-digbench. 
+*/
+
+// https://github.com/sosy-lab/sv-benchmarks/blob/master/c/nla-digbench/sqrt1.c
+/* Compute the floor of the square root of a natural number */
+extern int __VERIFIER_nondet_int(void);
+
+int main() {
+    int s, t, i, j;
+    // n = __VERIFIER_nondet_int();
+    i = __VERIFIER_nondet_int();
+    j = __VERIFIER_nondet_int();
+
+    s = 1;
+    t = 1;
+
+    while (t*t - 4*s + 2*t + 1 + i >= 0) {
+      //__VERIFIER_assert(t == 2*a + 1);
+      //__VERIFIER_assert(s == (a + 1) * (a + 1));
+      //__VERIFIER_assert(t*t - 4*s + 2*t + 1 == 0);
+        // the above 2 should be equiv to 
+      //if (!(s <= n))break;
+        t = t + 2;
+        s = s + t;
+        i = i + j;
+        j = j + 1;
+    }
+
+    /*
+    while (i >= 0) {
+      i = i + j;
+      j = j + 1;
+    }
+    */
+
+    //__VERIFIER_assert(t == 2 * a + 1);
+    //__VERIFIER_assert(s == (a + 1) * (a + 1));
+    //__VERIFIER_assert(t*t - 4*s + 2*t + 1 == 0);
+
+    return 0;
+}

--- a/c/termination-nla/sqrt2-both-nt.i
+++ b/c/termination-nla/sqrt2-both-nt.i
@@ -1,0 +1,15 @@
+extern int __VERIFIER_nondet_int(void);
+int main() {
+    int s, t, i, j;
+    i = __VERIFIER_nondet_int();
+    j = __VERIFIER_nondet_int();
+    s = 1;
+    t = 1;
+    while (t*t - 4*s + 2*t + 1 + i >= 0) {
+        t = t + 2;
+        s = s + t;
+        i = i + j;
+        j = j + 1;
+    }
+    return 0;
+}

--- a/c/termination-nla/sqrt2-both-nt.yml
+++ b/c/termination-nla/sqrt2-both-nt.yml
@@ -1,0 +1,9 @@
+format_version: '2.0'
+input_files: 'sqrt2-both-nt.c'
+properties:
+  - property_file: ../properties/termination.prp
+    expected_verdict: false
+
+options:
+  language: C
+  data_model: ILP32


### PR DESCRIPTION
Dear SV-COMP Community,

We would like to contribute our NLA termination benchmarks, which have been used in the OOPSLA'20 paper "DynamiTe: Dynamic termination and non-termination proofs" to `sv-benchmarks`. The benchmarks were added into the folder `c/termination-nla`. Please let us know if there are any issues. 

Thank you very much for your consideration. We are looking forward to your acceptance.

- [x] programs added to new and [appropriately named](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#directory-structure-and-names) directory
- [x] license present and [acceptable](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#license) (in machine-readable comment at beginning of program as specified by the [REUSE project](https://reuse.software/))
- [x] [contributed-by](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#origin-description-and-attribution) present (either in README file or as comment at beginning of program)

- [ ] programs added to a `.set` file of an existing category, or new sub-category established (if justified)
- [x] intended property matches the corresponding `.prp` file
- [x] programs and expected answer added to a `.yml` file according to [task definitions](https://github.com/sosy-lab/sv-benchmarks#task-definitions)

<!-- For C programs: -->
- [x] [data model](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#data-model) present in task-definition file
- [x] original (ideally not preprocessed) sources present
- [x] [preprocessed](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#preprocessing) files present
- [x] preprocessed files generated with correct architecture
- [x] [Makefile](https://github.com/sosy-lab/sv-benchmarks/blob/master/CONTRIBUTING.md#compile-checks) added with correct content and without overly broad suppression of warnings

On behalf of DynamiTe team,

Ton Chanh Le
