### PR TITLE
Add missing tasks to a category

### DIFF
--- a/c/SoftwareSystems-BusyBox-ReachSafety.set
+++ b/c/SoftwareSystems-BusyBox-ReachSafety.set
@@ -1,0 +1,2 @@
+# Contains problems from the software system BusyBox.
+busybox-1.22.0/*.yml


### PR DESCRIPTION
There are tasks with property unreach-call that are not yet included in the benchmark set.

The CI script for the benchmark definitions has identified this issue:
https://gitlab.com/sosy-lab/sv-comp/bench-defs/-/jobs/1624885676

Example for missing task: https://github.com/sosy-lab/sv-benchmarks/blob/master/c/busybox-1.22.0/cut-3.yml