### PR TITLE
Replace check-markdown-links with pandoc + linkchecker

### DIFF
--- a/.Dockerfile.link-checks
+++ b/.Dockerfile.link-checks
@@ -1,0 +1,22 @@
+# This file is part of the SV-Benchmarks collection of verification tasks:
+# https://github.com/sosy-lab/sv-benchmarks
+#
+# SPDX-FileCopyrightText: 2011-2021 The SV-Benchmarks Community
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This is a Docker image for running the sanity checks.
+# It should be pushed to registry.gitlab.com/sosy-lab/software/sv-benchmarks/ci/sanity-checks
+# and will be used by CI as declared in .gitlab-ci.yml.
+#
+# Commands for updating the image:
+# docker build --pull -t registry.gitlab.com/sosy-lab/software/sv-benchmarks/ci/link-checks:latest - < .Dockerfile.link-checks
+# docker push registry.gitlab.com/sosy-lab/software/sv-benchmarks/ci/link-checks
+
+FROM python:3
+
+RUN apt-get update && apt-get install -y pandoc \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install \
+  linkchecker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,10 +126,10 @@ java-format:
 
 check-links:
     stage: checks
-    image:
-        name: ghcr.io/tcort/markdown-link-check:stable
-        entrypoint: [""]
-    script: "find . -name '*.md' | xargs -n 1 /src/markdown-link-check"
+    image: "$CI_REGISTRY/sosy-lab/software/sv-benchmarks/ci/link-checks:latest"
+    script:
+      - "set -o pipefail"
+      - "for md in $(find . -name '*.md'); do pandoc -t html5 \"$md\" -o \"$md\".html; echo -e \"\\n\\nFILE: $md\"; linkchecker --check-extern --config .linkchecker.config  \"$md\".html; rm \"$md\".html; done" 
 
 .build-docker:
   image:
@@ -177,6 +177,13 @@ build-docker:java:latest:
   variables:
     DOCKERFILE: java/.Dockerfile
     IMAGE: ci/java:latest
+
+build-docker:link-checks:latest:
+  extends: .build-docker
+  stage: images
+  variables:
+    DOCKERFILE: .Dockerfile.link-checks
+    IMAGE: ci/link-checks:latest
 
 
 # check license declarations etc.

--- a/.linkchecker.config
+++ b/.linkchecker.config
@@ -1,3 +1,10 @@
+# This file is part of the SV-Benchmarks collection of verification tasks:
+# https://github.com/sosy-lab/sv-benchmarks
+#
+# SPDX-FileCopyrightText: 2021 The SV-Benchmarks Community
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [checking]
 recursionlevel=1
 

--- a/.linkchecker.config
+++ b/.linkchecker.config
@@ -1,0 +1,8 @@
+[checking]
+recursionlevel=1
+
+[output]
+status=0
+
+[text]
+parts=realurl,result,extern,base,name,parenturl,info,warning,url,outro


### PR DESCRIPTION
markdown-link-check does not solve https://github.com/tcort/markdown-link-check/issues/159,
which is a problem for us because of false positives in doi.org.
    
So we resort to the (less nice-looking) linkchecker.
We first convert markdown files to HTML through pandoc, and then pass them to linkchecker.

We use a new Dockerfile with linkchecker installed, and a config to keep the output in the CI readable.